### PR TITLE
Change patch key for GundiClient, to match the reference at time of use.

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -14,7 +14,6 @@ from .configurations import PullRmwHubObservationsConfiguration, AuthenticateCon
 from .rmwhub import RmwHubAdapter
 
 logger = logging.getLogger(__name__)
-_client = GundiClient()
 
 
 LOAD_BATCH_SIZE = 100
@@ -49,6 +48,7 @@ async def action_pull_observations(
 
     # TODO: Create sub-actions for each destination
     total_observations = []
+    _client = GundiClient()
     connection_details = await _client.get_connection_details(integration.id)
     for destination in connection_details.destinations:
         environment = Environment(destination.name)

--- a/app/services/tests/test_handlers.py
+++ b/app/services/tests/test_handlers.py
@@ -26,7 +26,7 @@ async def test_handler_action_pull_observations(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
-    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.actions.handlers.GundiClient", mock_gundi_client_v2_class)
     mocker.patch(
         "app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class
     )


### PR DESCRIPTION
Here's a small change to get past your issue with mocking `GundiClient`.

Next you'll need to provide a mock payload for `get_connection_details()`
