### PR TITLE
RF-834: Trap ID 32 char length requirement and some fixes found during QA testing

### DIFF
--- a/app/actions/buoy.py
+++ b/app/actions/buoy.py
@@ -60,10 +60,8 @@ class BuoyClient:
             if len(data["data"]) == 0:
                 logger.error(f"No observations found")
                 return {}
-            if page_size == 1:
-                return data["data"]["results"][0]
-            else:
-                return data["data"]["results"]
+
+            return data["data"]["results"]
         else:
             logger.error(
                 f"Failed to get latest observation. Status code: {response.status_code}"

--- a/app/actions/buoy.py
+++ b/app/actions/buoy.py
@@ -41,6 +41,56 @@ class BuoyClient:
 
         return []
 
+    async def get_latest_observation(self, subject_id: str) -> dict:
+        """
+        Get the latest observation for a subject
+        """
+        url = (
+            self.er_site
+            + f"/observations/?sort_by=-recorded_at&subject_id={subject_id}&include_details=true"
+        )
+        BuoyClient.headers["Authorization"] = f"Bearer {self.er_token}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=BuoyClient.headers)
+
+        if response.status_code == 200:
+            logger.info("Request to get latest observation was successful")
+            data = json.loads(response.text)
+            if len(data["data"]) == 0:
+                logger.error(f"No observations found")
+                return {}
+            return data["data"]["results"][0]
+        else:
+            logger.error(
+                f"Failed to get latest observation. Status code: {response.status_code}"
+            )
+
+        return {}
+
+    async def get_gear(self) -> List:
+        """
+        Get all gear
+        """
+
+        url = self.er_site + f"/gear/"
+        BuoyClient.headers["Authorization"] = f"Bearer {self.er_token}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=BuoyClient.headers)
+
+        if response.status_code == 200:
+            logger.info("Request to get ER gear was successful")
+            data = json.loads(response.text)
+            if len(data["data"]) == 0:
+                logger.error(f"No gear found")
+                return []
+            return data["data"]
+        else:
+            logger.error(f"Failed to make request. Status code: {response.status_code}")
+
+        return []
+
     async def get_er_subject_by_name(self, name: str) -> dict:
 
         url = (

--- a/app/actions/buoy.py
+++ b/app/actions/buoy.py
@@ -41,13 +41,13 @@ class BuoyClient:
 
         return []
 
-    async def get_latest_observation(self, subject_id: str) -> dict:
+    async def get_latest_observations(self, subject_id: str, page_size: int) -> dict:
         """
-        Get the latest observation for a subject
+        Get the latest observations for a subject. Return only the latest observation when page_size = 1.
         """
         url = (
             self.er_site
-            + f"/observations/?sort_by=-recorded_at&subject_id={subject_id}&include_details=true"
+            + f"/observations/?sort_by=-recorded_at&subject_id={subject_id}&include_details=true&page_size={page_size}"
         )
         BuoyClient.headers["Authorization"] = f"Bearer {self.er_token}"
 
@@ -60,7 +60,10 @@ class BuoyClient:
             if len(data["data"]) == 0:
                 logger.error(f"No observations found")
                 return {}
-            return data["data"]["results"][0]
+            if page_size == 1:
+                return data["data"]["results"][0]
+            else:
+                return data["data"]["results"]
         else:
             logger.error(
                 f"Failed to get latest observation. Status code: {response.status_code}"

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -128,7 +128,7 @@ async def action_pull_observations(
             (
                 put_set_id_observations,
                 rmw_response,
-            ) = await rmw_adapter.process_rmw_upload(rmwSets, start_datetime_str)
+            ) = await rmw_adapter.process_rmw_upload(start_datetime_str)
         except ValueError as e:
             logger.error(f"Failed to upload changes to RMW Hub: {str(e)}")
             put_set_id_observations = []

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -144,7 +144,7 @@ async def action_pull_observations(
         # observations.extend(put_set_id_observations)
 
         # TODO: Handle failed response
-        await log_activity(
+        await log_action_activity(
             integration_id=integration.id,
             action_id="pull_observations",
             level=LogLevel.INFO,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -248,7 +248,7 @@ async def action_pull_observations_24_hour_sync(
 
         # Upload changes from ER to RMW Hub
         put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(
-            rmwSets, start_datetime_str
+            start_datetime_str
         )
         total_observations.extend(put_set_id_observations)
         observations.extend(put_set_id_observations)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -53,7 +53,6 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
 async def action_pull_observations(
     integration, action_config: PullRmwHubObservationsConfiguration
 ):
-    action_config.rmw_url = "https://test.ropeless.network/api"
     current_datetime = datetime.now()
     sync_interval_minutes = 5
     start_datetime = current_datetime - timedelta(minutes=sync_interval_minutes)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -139,13 +139,6 @@ async def action_pull_observations(
             put_set_id_observations = []
             rmw_response = {}
 
-        total_observations.extend(put_set_id_observations)
-
-        # TODO: Check if the uploaded observations to rmwhub should be added to the observations
-        # TODO: since when push_status_updates is called it won't find it in rmwSets
-        # TODO: (because it is an "own" gear, not "hub" gear)
-        # observations.extend(put_set_id_observations)
-
         # TODO: Handle failed response
         await log_action_activity(
             integration_id=integration.id,
@@ -262,8 +255,6 @@ async def action_pull_observations_24_hour_sync(
         put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(
             start_datetime_str
         )
-        total_observations.extend(put_set_id_observations)
-        observations.extend(put_set_id_observations)
 
         # TODO: Handle failed response
         await log_activity(

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -107,7 +107,7 @@ class GearSet(BaseModel):
     deployment_type: str
     traps_in_set: int
     trawl_path: str
-    share_with: List[str]
+    share_with: Optional[List[str]]
     traps: List[Trap]
     when_updated_utc: str
 

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -541,6 +541,18 @@ class RmwHubAdapter:
 
             rmwhub_set_id = latest_observation["observation_details"]["rmwhub_set_id"]
 
+            if rmwhub_set_id not in rmw_set_id_to_gearset_mapping.keys():
+                logger.error(
+                    f"RMW Set ID {rmwhub_set_id} not found in RMW sets. No action."
+                )
+                log_action_activity(
+                    integration_id=self.integration_id,
+                    action_id="pull_observations",
+                    title=f"RMW Set ID {rmwhub_set_id} not found in RMW sets. No action.",
+                    level=LogLevel.ERROR,
+                )
+                continue
+
             # Create new updates from ER data for upload to RMWHub
             rmw_gearset = rmw_set_id_to_gearset_mapping[rmwhub_set_id]
             updated_gearset = await self._create_rmw_update_from_er_subject(

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -80,7 +80,7 @@ class Trap(BaseModel):
         Convert the datetime string to UTC.
         """
 
-        datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
+        datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
         datetime_obj = datetime_obj.astimezone(pytz.utc)
         return datetime_obj
 
@@ -826,7 +826,7 @@ class RmwHubAdapter:
 
             # TODO: This should use the subjects latest observation recorded at value
             last_updated_utc = self.convert_datetime_to_utc(
-                er_subject.get("last_position_date")
+                er_subject.get("updated_at")
             )
             if deployed:
                 traps.append(

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -1,21 +1,15 @@
-from datetime import datetime, timedelta
-from dateparser import parse as parse_date
-from enum import Enum
 import hashlib
 import json
 import logging
-
-from fastapi.encoders import jsonable_encoder
-import pytz
 import uuid
-from datetime import datetime, timezone
-
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import List, Optional, Tuple
 
 import httpx
 import pytz
 import stamina
+from dateparser import parse as parse_date
 from fastapi.encoders import jsonable_encoder
 from gundi_core.schemas.v2.gundi import LogLevel
 from pydantic import BaseModel, NoneStr, validator
@@ -83,12 +77,6 @@ class Trap(BaseModel):
         """
         Convert the datetime string to UTC.
         """
-        try:
-            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
-        except ValueError:
-            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
-
-
         naive_datetime_obj = parse_date(datetime_str)
         utc_datetime_obj = naive_datetime_obj.replace(tzinfo=timezone.utc)
         if not utc_datetime_obj:
@@ -515,7 +503,7 @@ class RmwHubAdapter:
                 )
                 continue
             # Use display_id for ER subjects to ensure uniqueness among gear sets
-            elif await self.clean_id_str(subject_name) in rmw_trap_ids:
+            elif self.clean_id_str(subject_name) in rmw_trap_ids:
                 if not subject.get("additional") or not subject.get("additional").get(
                     "devices"
                 ):
@@ -871,7 +859,7 @@ class RmwHubAdapter:
             # TODO: Use subject.id instead of subject.name for the trap ID
             # TODO: Determine the effects of this^ change on the download/upload process
             subject_name = er_subject.get("name")
-            cleaned_id = await validate_id_length(await self.clean_id_str(subject_name))
+            cleaned_id = await validate_id_length(self.clean_id_str(subject_name))
 
             trap_id = (
                 cleaned_id

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -5,7 +5,7 @@ import logging
 from fastapi.encoders import jsonable_encoder
 import pytz
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from enum import Enum
 from typing import List, Optional, Tuple
@@ -255,9 +255,7 @@ class RmwHubAdapter:
         ref: https://ropeless.network/api/docs#/Download
         """
 
-        response = await self.rmw_client.search_hub(
-            start_datetime_str, minute_interval, status
-        )
+        response = await self.rmw_client.search_hub(start_datetime_str, status)
 
         return self.convert_to_sets(response)
 
@@ -309,7 +307,7 @@ class RmwHubAdapter:
             )
 
             gearsets.append(gearset)
-        
+
         return RmwSets(sets=gearsets)
 
     async def process_rmw_download(

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -533,9 +533,10 @@ class RmwHubAdapter:
             logger.info(f"Subject ID {subject.get('name')} found in RMW traps.")
 
             # Get the latest observation for the subject
-            latest_observation = await self.er_client.get_latest_observations(
+            latest_observations = await self.er_client.get_latest_observations(
                 subject.get("id"), 1
             )
+            latest_observation = latest_observations[0]
 
             # TODO: fix
             if not latest_observation["observation_details"].get("rmwhub_set_id"):
@@ -816,7 +817,7 @@ class RmwHubAdapter:
             # TODO: Use subject.id instead of subject.name for the trap ID
             # TODO: Determine the effects of this^ change on the download/upload process
             subject_name = er_subject.get("name")
-            cleaned_id = validate_id_length(await self.clean_id_str(subject_name))
+            cleaned_id = await validate_id_length(await self.clean_id_str(subject_name))
             trap_id = (
                 cleaned_id
                 if rmw_gearset and subject_name.startswith("rmw")

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -79,8 +79,11 @@ class Trap(BaseModel):
         """
         Convert the datetime string to UTC.
         """
+        try:
+            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
+        except ValueError:
+            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
 
-        datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
         datetime_obj = datetime_obj.astimezone(pytz.utc)
         return datetime_obj
 

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -668,7 +668,7 @@ def mock_er_subjects():
         {
             "content_type": "observations.subject",
             "id": "0302a774-1971-4a64-8264-1d7f17969442",
-            "name": "FBB01895-0BC3-4498-ACAC-BCBCE12F1363",
+            "name": "short_name",
             "subject_type": "ropeless_buoy",
             "subject_subtype": "ropeless_buoy_device",
             "common_name": None,

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -691,6 +691,28 @@ def mock_er_subjects():
             "user": None,
             "tracks_available": False,
             "image_url": "/static/pin-black.svg",
+            "last_position_date": "2025-01-16T17:33:21+00:00",
+            "last_position": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-70.443459307605, 41.83290438292462],
+                },
+                "properties": {
+                    "title": "edgetech_88CE99D36A_A",
+                    "subject_type": "ropeless_buoy",
+                    "subject_subtype": "ropeless_buoy_device",
+                    "id": "0006a86a-9a99-4112-94b7-f72190ff178f",
+                    "stroke": "#FFFF00",
+                    "stroke-opacity": 1.0,
+                    "stroke-width": 2,
+                    "image": "https://buoy.dev.pamdas.org/static/pin-black.svg",
+                    "radio_state_at": "1970-01-01T00:00:00+00:00",
+                    "radio_state": "na",
+                    "coordinateProperties": {"time": "2025-01-16T17:33:21+00:00"},
+                    "DateTime": "2025-01-16T17:33:21+00:00",
+                },
+            },
             "url": "https://buoy.dev.pamdas.org/api/v1.0/subject/0302a774-1971-4a64-8264-1d7f17969442",
         },
         {
@@ -725,6 +747,28 @@ def mock_er_subjects():
             "user": None,
             "tracks_available": False,
             "image_url": "/static/pin-black.svg",
+            "last_position_date": "2025-01-16T17:33:21+00:00",
+            "last_position": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-70.443459307605, 41.83290438292462],
+                },
+                "properties": {
+                    "title": "edgetech_88CE99D36A_A",
+                    "subject_type": "ropeless_buoy",
+                    "subject_subtype": "ropeless_buoy_device",
+                    "id": "0006a86a-9a99-4112-94b7-f72190ff178f",
+                    "stroke": "#FFFF00",
+                    "stroke-opacity": 1.0,
+                    "stroke-width": 2,
+                    "image": "https://buoy.dev.pamdas.org/static/pin-black.svg",
+                    "radio_state_at": "1970-01-01T00:00:00+00:00",
+                    "radio_state": "na",
+                    "coordinateProperties": {"time": "2025-01-16T17:33:21+00:00"},
+                    "DateTime": "2025-01-16T17:33:21+00:00",
+                },
+            },
             "url": "https://buoy.dev.pamdas.org/api/v1.0/subject/081bfce1-e977-46ad-b948-aa90c9283304",
         },
         {
@@ -759,6 +803,28 @@ def mock_er_subjects():
             "user": None,
             "tracks_available": False,
             "image_url": "/static/pin-black.svg",
+            "last_position_date": "2025-01-16T17:33:21+00:00",
+            "last_position": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-70.443459307605, 41.83290438292462],
+                },
+                "properties": {
+                    "title": "edgetech_88CE99D36A_A",
+                    "subject_type": "ropeless_buoy",
+                    "subject_subtype": "ropeless_buoy_device",
+                    "id": "0006a86a-9a99-4112-94b7-f72190ff178f",
+                    "stroke": "#FFFF00",
+                    "stroke-opacity": 1.0,
+                    "stroke-width": 2,
+                    "image": "https://buoy.dev.pamdas.org/static/pin-black.svg",
+                    "radio_state_at": "1970-01-01T00:00:00+00:00",
+                    "radio_state": "na",
+                    "coordinateProperties": {"time": "2025-01-16T17:33:21+00:00"},
+                    "DateTime": "2025-01-16T17:33:21+00:00",
+                },
+            },
             "url": "https://buoy.dev.pamdas.org/api/v1.0/subject/0931ddaa-770c-4bb4-9d66-b8106c17e043",
         },
     ]
@@ -969,5 +1035,95 @@ def mock_er_subjects_from_rmw():
             "tracks_available": False,
             "image_url": "/static/pin-black.svg",
             "url": "https://buoy.dev.pamdas.org/api/v1.0/subject/0931ddaa-770c-4bb4-9d66-b8106c17e043",
+        },
+    ]
+
+
+@pytest.fixture
+def mock_latest_observations():
+    return [
+        {
+            "id": "82d599d7-62f1-4620-bab4-0415fa8e6b4b",
+            "location": {"latitude": 34.472032, "longitude": -123.10975},
+            "created_at": "2024-10-09T17:00:54.182801-07:00",
+            "recorded_at": "2020-07-31T11:58:33-07:00",
+            "source": "7107445c-d883-423b-84d9-3525e7a37c8c",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 34.472032, "longitude": -123.10975},
+                        "device_id": "100",
+                        "last_updated": "2020-07-31T18:58:33+00:00",
+                    }
+                ],
+                "display_id": "9f9a88df5fbc",
+                "event_type": "smelts_buoy_deployment",
+                "radio_state": "online-gps",
+            },
+        },
+        {
+            "id": "207b5901-b3d7-4a04-8b2a-e3121b452ad3",
+            "location": {"latitude": 34.472032, "longitude": -123.10975},
+            "created_at": "2024-10-14T20:55:11.392267-07:00",
+            "recorded_at": "2020-07-31T11:58:33-07:00",
+            "source": "34ba3be1-b25e-411a-8d39-2a4b777bcbb1",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 34.472032, "longitude": -123.10975},
+                        "device_id": "device_100",
+                        "last_updated": "2020-07-31T18:58:33+00:00",
+                    }
+                ],
+                "display_id": "c242b9e4c9d9",
+                "event_type": "smelts_buoy_deployment",
+                "radio_state": "online-gps",
+            },
+        },
+        {
+            "id": "b404c5b9-bdd2-49f9-a036-80fab8393b6c",
+            "location": {"latitude": 41.876497, "longitude": -70.273052},
+            "created_at": "2024-10-14T20:55:00.331752-07:00",
+            "recorded_at": "2022-05-20T11:18:17-07:00",
+            "source": "a8db9e65-280b-4c5c-8d1d-caf568761e28",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 41.876497, "longitude": -70.273052},
+                        "device_id": "device_9909",
+                        "last_updated": "2022-05-20T18:18:17+00:00",
+                    }
+                ],
+                "display_id": "28d27646abdf",
+                "event_type": "smelts_buoy_subsea_data",
+                "radio_state": "online-gps",
+            },
+        },
+        {
+            "id": "112c4f7e-c17b-4e5a-8e3d-de576d1ad121",
+            "location": {"latitude": 41.876497, "longitude": -70.273052},
+            "created_at": "2024-10-09T17:00:50.031504-07:00",
+            "recorded_at": "2022-05-20T11:18:17-07:00",
+            "source": "823baa3b-47ea-4b08-bc55-cb6b666d220f",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 41.876497, "longitude": -70.273052},
+                        "device_id": "9909",
+                        "last_updated": "2022-05-20T18:18:17+00:00",
+                    }
+                ],
+                "display_id": "394f4fc71b46",
+                "event_type": "smelts_buoy_subsea_data",
+                "radio_state": "online-gps",
+            },
         },
     ]

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -171,9 +171,17 @@ async def test_rmwhub_adapter_process_rmw_upload_insert_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=result,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[]), start_datetime_str
+        start_datetime_str
     )
 
     assert len(observations) == 0
@@ -188,9 +196,17 @@ async def test_rmwhub_adapter_process_rmw_upload_insert_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=mock_rmw_upload_response,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[mock_rmwhub_items[0]]), start_datetime_str
+        start_datetime_str
     )
     assert len(observations) == 5
     assert rmw_response["trap_count"] == 5
@@ -206,9 +222,17 @@ async def test_rmwhub_adapter_process_rmw_upload_insert_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=mock_rmw_upload_response,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[mock_rmwhub_items[0]]), start_datetime_str
+        start_datetime_str
     )
     assert len(observations) == 0
     assert rmw_response["trap_count"] == 0
@@ -222,6 +246,7 @@ async def test_rmwhub_adapter_process_rmw_upload_update_success(
     mock_rmwhub_items_update,
     mock_er_subjects_update,
     mock_rmw_upload_response,
+    mock_latest_observations,
 ):
     """
     Test RmwHubAdapter.process_rmw_upload update operations
@@ -249,9 +274,20 @@ async def test_rmwhub_adapter_process_rmw_upload_update_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=mock_rmw_upload_response,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=mock_rmwhub_items_update),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_latest_observations",
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=mock_rmwhub_items_update), start_datetime_str
+        start_datetime_str
     )
     # There will be no new observsation for items originally from RMW
     # because the set ID has already been added.
@@ -288,9 +324,17 @@ async def test_rmwhub_adapter_process_rmw_upload_failure(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value={},
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[mock_rmwhub_items[0]]), start_datetime_str
+        start_datetime_str
     )
     assert len(observations) == 0
     assert rmw_response == {}

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -341,7 +341,7 @@ async def test_rmwhub_adapter_process_rmw_upload_failure(
 
 
 @pytest.mark.asyncio
-async def test_create_rmw_update_from_er_subject(
+async def test_rmwhub_adapter_create_rmw_update_from_er_subject(
     mocker,
     a_good_integration,
     a_good_configuration,


### PR DESCRIPTION
### What does this PR do
Mandates a 32 minimum character length requirement for Trap IDs uploaded to rmwHub. 
Bug fixes outlined in commit messages include:
- add new additional.devices field "last_deployed"
- Add error handling for missing rmwHub set IDs
- Add logic to use last_observations to determine the latest_deploment_time.
- Use subject.last_position_date to determine the last observation time.
- Fix gearsets in rmwHub not updating

### Dev Validation
Created a Gear set using this observation
```
{
    "source_type": "ropeless_buoy",
    "subject_name": "rf-834_short_id",
    "manufacturer_id": "rf-834_short_id",
    "is_active": false,
    "subject_subtype": "ropeless_buoy_device",
    "recorded_at": "2025-01-30T12:44:00+00:00",
    "location": {
        "lat": "0.0",
        "lon": "0.0"
    },
    "additional": {
        "devices": [
            {
              "label": "a",
              "location": {
                "latitude": 0.0,
                "longitude": 0.0
              },
              "device_id": "rf-834_short_id",
              "last_updated": "2025-01-27T04:00:00+00:00"
            }
          ],
          "display_id": "faf5a4cce544",        
          "event_type": "gear_deployed"
          }
}
```
Successful action runner execution:
<img width="1440" alt="Screenshot 2025-03-17 at 3 35 15 PM" src="https://github.com/user-attachments/assets/bcb6221a-2dc5-4e85-90ad-9b0c4eb0d882" />
Validation that gearset is added to rmwHub:
<img width="704" alt="Screenshot 2025-03-17 at 3 37 15 PM" src="https://github.com/user-attachments/assets/335f0ced-2a66-474e-8645-bb4419581b19" />


### Relevant Links 
[RF-834](https://allenai.atlassian.net/browse/RF-834)


[RF-834]: https://allenai.atlassian.net/browse/RF-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ