### PR TITLE
RF-847: Download incorrectly filters gearsets from rmwHub

### DIFF
--- a/app/actions/buoy.py
+++ b/app/actions/buoy.py
@@ -41,6 +41,57 @@ class BuoyClient:
 
         return []
 
+    async def get_latest_observations(self, subject_id: str, page_size: int) -> dict:
+        """
+        Get the latest observations for a subject. Return only the latest observation when page_size = 1.
+        """
+        url = (
+            self.er_site
+            + f"/observations/?sort_by=-recorded_at&subject_id={subject_id}&include_details=true&page_size={page_size}"
+        )
+        BuoyClient.headers["Authorization"] = f"Bearer {self.er_token}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=BuoyClient.headers)
+
+        if response.status_code == 200:
+            logger.info("Request to get latest observation was successful")
+            data = json.loads(response.text)
+            if len(data["data"]) == 0:
+                logger.error(f"No observations found")
+                return {}
+
+            return data["data"]["results"]
+        else:
+            logger.error(
+                f"Failed to get latest observation. Status code: {response.status_code}"
+            )
+
+        return {}
+
+    async def get_gear(self) -> List:
+        """
+        Get all gear
+        """
+
+        url = self.er_site + f"/gear/"
+        BuoyClient.headers["Authorization"] = f"Bearer {self.er_token}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=BuoyClient.headers)
+
+        if response.status_code == 200:
+            logger.info("Request to get ER gear was successful")
+            data = json.loads(response.text)
+            if len(data["data"]) == 0:
+                logger.error(f"No gear found")
+                return []
+            return data["data"]
+        else:
+            logger.error(f"Failed to make request. Status code: {response.status_code}")
+
+        return []
+
     async def get_er_subject_by_name(self, name: str) -> dict:
 
         url = (

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -126,40 +126,41 @@ async def action_pull_observations(
             )
 
         # Upload changes from ER to RMW Hub
-        try:
-            (
-                put_set_id_observations,
-                rmw_response,
-            ) = await rmw_adapter.process_rmw_upload(start_datetime_str)
+        rmw_response = {}
+        # try:
+        #     (
+        #         put_set_id_observations,
+        #         rmw_response,
+        #     ) = await rmw_adapter.process_rmw_upload(start_datetime_str)
 
-            if rmw_response and "detail" in rmw_response:
-                await log_action_activity(
-                    integration_id=integration.id,
-                    action_id="pull_observations",
-                    level=LogLevel.ERROR,
-                    title="Failed to upload data to rmwHub.",
-                    data={
-                        "rmw_response": str(rmw_response),
-                    },
-                    config_data=action_config.dict(),
-                )
-            else:
-                await log_action_activity(
-                    integration_id=integration.id,
-                    action_id="pull_observations",
-                    level=LogLevel.INFO,
-                    title="Process upload to rmwHub completed.",
-                    data={
-                        "rmw_response": str(rmw_response),
-                    },
-                    config_data=action_config.dict(),
-                )
-        except ValueError as e:
-            logger.error(f"Failed to upload changes to RMW Hub: {str(e)}")
-            put_set_id_observations = []
-            rmw_response = {}
+        #     if rmw_response and "detail" in rmw_response:
+        #         await log_action_activity(
+        #             integration_id=integration.id,
+        #             action_id="pull_observations",
+        #             level=LogLevel.ERROR,
+        #             title="Failed to upload data to rmwHub.",
+        #             data={
+        #                 "rmw_response": str(rmw_response),
+        #             },
+        #             config_data=action_config.dict(),
+        #         )
+        #     else:
+        #         await log_action_activity(
+        #             integration_id=integration.id,
+        #             action_id="pull_observations",
+        #             level=LogLevel.INFO,
+        #             title="Process upload to rmwHub completed.",
+        #             data={
+        #                 "rmw_response": str(rmw_response),
+        #             },
+        #             config_data=action_config.dict(),
+        #         )
+        # except ValueError as e:
+        #     logger.error(f"Failed to upload changes to RMW Hub: {str(e)}")
+        #     put_set_id_observations = []
+        #     rmw_response = {}
 
-        total_observations.extend(put_set_id_observations)
+        # total_observations.extend(put_set_id_observations)
         # TODO: Check if the uploaded observations to rmwhub should be added to the observations
         # TODO: since when push_status_updates is called it won't find it in rmwSets
         # TODO: (because it is an "own" gear, not "hub" gear)
@@ -179,10 +180,15 @@ async def action_pull_observations(
         )
 
     # The result will be recorded in the portal if using the activity_logger decorator
-    return {
-        "observations_extracted": len(total_observations),
-        "rmw_updates": rmw_response,
-    }
+    if rmw_response:
+        return {
+            "observations_extracted": len(total_observations),
+            "rmw_updates": rmw_response,
+        }
+    else:
+        return {
+            "observations_extracted": len(total_observations),
+        }
 
 
 @activity_logger()
@@ -261,34 +267,33 @@ async def action_pull_observations_24_hour_sync(
             )
 
         # Upload changes from ER to RMW Hub
-        put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(
-            start_datetime_str
-        )
-        total_observations.extend(put_set_id_observations)
-        # observations.extend(put_set_id_observations)
+        rmw_response = {}
+        # put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(start_datetime_str)
+        # total_observations.extend(put_set_id_observations)
+        # # observations.extend(put_set_id_observations)
 
-        if rmw_response and "detail" in rmw_response:
-            await log_action_activity(
-                integration_id=integration.id,
-                action_id="pull_observations_24_hour_sync",
-                level=LogLevel.ERROR,
-                title="Failed to upload data to rmwHub.",
-                data={
-                    "rmw_response": str(rmw_response),
-                },
-                config_data=action_config.dict(),
-            )
-        else:
-            await log_action_activity(
-                integration_id=integration.id,
-                action_id="pull_observations_24_hour_sync",
-                level=LogLevel.INFO,
-                title="Process upload to rmwHub completed.",
-                data={
-                    "rmw_response": str(rmw_response),
-                },
-                config_data=action_config.dict(),
-            )
+        # if rmw_response and "detail" in rmw_response:
+        #     await log_action_activity(
+        #         integration_id=integration.id,
+        #         action_id="pull_observations_24_hour_sync",
+        #         level=LogLevel.ERROR,
+        #         title="Failed to upload data to rmwHub.",
+        #         data={
+        #             "rmw_response": str(rmw_response),
+        #         },
+        #         config_data=action_config.dict(),
+        #     )
+        # else:
+        #     await log_action_activity(
+        #         integration_id=integration.id,
+        #         action_id="pull_observations_24_hour_sync",
+        #         level=LogLevel.INFO,
+        #         title="Process upload to rmwHub completed.",
+        #         data={
+        #             "rmw_response": str(rmw_response),
+        #         },
+        #         config_data=action_config.dict(),
+        #     )
 
         # Send the extracted data to Gundi in batches
         for batch in generate_batches(observations):
@@ -303,10 +308,15 @@ async def action_pull_observations_24_hour_sync(
         )
 
     # The result will be recorded in the portal if using the activity_logger decorator
-    return {
-        "observations_extracted": len(total_observations),
-        "rmw_updates": rmw_response,
-    }
+    if rmw_response:
+        return {
+            "observations_extracted": len(total_observations),
+            "rmw_updates": rmw_response,
+        }
+    else:
+        return {
+            "observations_extracted": len(total_observations),
+        }
 
 
 def generate_batches(iterable, n=LOAD_BATCH_SIZE):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -4,14 +4,15 @@ import logging
 from datetime import datetime, timedelta
 from typing import Tuple
 
-from app.services.action_scheduler import crontab_schedule
-from app.services.activity_logger import activity_logger, log_activity
-from app.services.gundi import send_observations_to_gundi
-from app.services.utils import find_config_for_action
+from gundi_client_v2 import GundiClient
 from gundi_core import schemas
 from gundi_core.events import LogLevel
 from gundi_core.schemas.v2 import Integration
-from gundi_client_v2 import GundiClient
+
+from app.services.action_scheduler import crontab_schedule
+from app.services.activity_logger import activity_logger, log_action_activity
+from app.services.gundi import send_observations_to_gundi
+from app.services.utils import find_config_for_action
 
 from .configurations import PullRmwHubObservationsConfiguration, AuthenticateConfig
 from .rmwhub import RmwHubAdapter
@@ -80,13 +81,14 @@ async def action_pull_observations(
         )
 
         logger.info(
-            f"Downloading data from RMW Hub API...For the dates: {start_datetime_str} - {end_datetime_str}"
+            f"Downloading data from RMW Hub API...For the datetimes: {start_datetime_str} - {end_datetime_str}"
         )
-        rmwSets = await rmw_adapter.download_data(
-            start_datetime_str, sync_interval_minutes
+        rmwSets = await rmw_adapter.download_data(start_datetime_str)
+        logger.info(
+            f"{len(rmwSets.sets)} Gearsets Downloaded from RMW Hub API...For the datetimes: {start_datetime_str} - {end_datetime_str}"
         )
 
-        await log_activity(
+        await log_action_activity(
             integration_id=integration.id,
             action_id="pull_observations",
             level=LogLevel.INFO,
@@ -95,6 +97,7 @@ async def action_pull_observations(
                 "start_date_time": start_datetime_str,
                 "end_date_time": end_datetime_str,
                 "environment": str(environment),
+                "gear_sets_to_process": len(rmwSets.sets),
             },
             config_data=action_config.dict(),
         )
@@ -109,7 +112,7 @@ async def action_pull_observations(
             )
             total_observations.extend(observations)
         else:
-            await log_activity(
+            await log_action_activity(
                 integration_id=integration.id,
                 action_id="pull_observations",
                 level=LogLevel.INFO,
@@ -123,23 +126,44 @@ async def action_pull_observations(
             )
 
         # Upload changes from ER to RMW Hub
-        # put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        #     rmwSets, start_datetime_str
-        # )
-        # total_observations.extend(put_set_id_observations)
-        # observations.extend(put_set_id_observations)
+        try:
+            (
+                put_set_id_observations,
+                rmw_response,
+            ) = await rmw_adapter.process_rmw_upload(start_datetime_str)
 
-        # # TODO: Handle failed response
-        # await log_activity(
-        #     integration_id=integration.id,
-        #     action_id="pull_observations",
-        #     level=LogLevel.INFO,
-        #     title="Process upload to rmwHub completed.",
-        #     data={
-        #         "rmw_response": str(rmw_response),
-        #     },
-        #     config_data=action_config.dict(),
-        # )
+            if rmw_response and "detail" in rmw_response:
+                await log_action_activity(
+                    integration_id=integration.id,
+                    action_id="pull_observations",
+                    level=LogLevel.ERROR,
+                    title="Failed to upload data to rmwHub.",
+                    data={
+                        "rmw_response": str(rmw_response),
+                    },
+                    config_data=action_config.dict(),
+                )
+            else:
+                await log_action_activity(
+                    integration_id=integration.id,
+                    action_id="pull_observations",
+                    level=LogLevel.INFO,
+                    title="Process upload to rmwHub completed.",
+                    data={
+                        "rmw_response": str(rmw_response),
+                    },
+                    config_data=action_config.dict(),
+                )
+        except ValueError as e:
+            logger.error(f"Failed to upload changes to RMW Hub: {str(e)}")
+            put_set_id_observations = []
+            rmw_response = {}
+
+        total_observations.extend(put_set_id_observations)
+        # TODO: Check if the uploaded observations to rmwhub should be added to the observations
+        # TODO: since when push_status_updates is called it won't find it in rmwSets
+        # TODO: (because it is an "own" gear, not "hub" gear)
+        # observations.extend(put_set_id_observations)
 
         # Send the extracted data to Gundi in batches
         for batch in generate_batches(observations):
@@ -155,7 +179,10 @@ async def action_pull_observations(
         )
 
     # The result will be recorded in the portal if using the activity_logger decorator
-    return {"observations_extracted": len(total_observations)}
+    return {
+        "observations_extracted": len(total_observations),
+        "rmw_updates": rmw_response,
+    }
 
 
 @activity_logger()
@@ -194,12 +221,10 @@ async def action_pull_observations_24_hour_sync(
         logger.info(
             f"Downloading data from RMW Hub API...For the dates: {start_datetime_str} - {end_datetime_str}"
         )
-        rmwSets = await rmw_adapter.download_data(
-            start_datetime_str, sync_interval_minutes
-        )
+        rmwSets = await rmw_adapter.download_data(start_datetime_str)
 
         # Optionally, log a custom messages to be shown in the portal
-        await log_activity(
+        await log_action_activity(
             integration_id=integration.id,
             action_id="pull_observations",
             level=LogLevel.INFO,
@@ -222,7 +247,7 @@ async def action_pull_observations_24_hour_sync(
             )
             total_observations.extend(observations)
         else:
-            await log_activity(
+            await log_action_activity(
                 integration_id=integration.id,
                 action_id="pull_observations",
                 level=LogLevel.INFO,
@@ -236,23 +261,34 @@ async def action_pull_observations_24_hour_sync(
             )
 
         # Upload changes from ER to RMW Hub
-        # put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        #     rmwSets, start_datetime_str
-        # )
-        # total_observations.extend(put_set_id_observations)
+        put_set_id_observations, rmw_response = await rmw_adapter.process_rmw_upload(
+            start_datetime_str
+        )
+        total_observations.extend(put_set_id_observations)
         # observations.extend(put_set_id_observations)
 
-        # # TODO: Handle failed response
-        # await log_activity(
-        #     integration_id=integration.id,
-        #     action_id="pull_observations",
-        #     level=LogLevel.INFO,
-        #     title="Process upload to rmwHub completed.",
-        #     data={
-        #         "rmw_response": str(rmw_response),
-        #     },
-        #     config_data=action_config.dict(),
-        # )
+        if rmw_response and "detail" in rmw_response:
+            await log_action_activity(
+                integration_id=integration.id,
+                action_id="pull_observations_24_hour_sync",
+                level=LogLevel.ERROR,
+                title="Failed to upload data to rmwHub.",
+                data={
+                    "rmw_response": str(rmw_response),
+                },
+                config_data=action_config.dict(),
+            )
+        else:
+            await log_action_activity(
+                integration_id=integration.id,
+                action_id="pull_observations_24_hour_sync",
+                level=LogLevel.INFO,
+                title="Process upload to rmwHub completed.",
+                data={
+                    "rmw_response": str(rmw_response),
+                },
+                config_data=action_config.dict(),
+            )
 
         # Send the extracted data to Gundi in batches
         for batch in generate_batches(observations):
@@ -267,7 +303,10 @@ async def action_pull_observations_24_hour_sync(
         )
 
     # The result will be recorded in the portal if using the activity_logger decorator
-    return {"observations_extracted": len(total_observations)}
+    return {
+        "observations_extracted": len(total_observations),
+        "rmw_updates": rmw_response,
+    }
 
 
 def generate_batches(iterable, n=LOAD_BATCH_SIZE):

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -448,15 +448,16 @@ class RmwHubAdapter:
 
         return observations
 
-    async def process_rmw_upload(
-        self, rmw_sets: RmwSets, start_datetime_str
-    ) -> Tuple[List, dict]:
+    async def process_rmw_upload(self, start_datetime_str) -> Tuple[List, dict]:
         """
         Process the sets from the Buoy API and upload to RMWHub.
         Returns a list of new observations for Earthranger with the new RmwHub set IDs.
         """
 
         logger.info("Processing updates to RMW Hub from ER...")
+
+        # Download data from search_own endpoint in RMWHub
+        rmw_sets = await self.search_own()
 
         # Normalize the extracted data into a list of updates following to the RMWHub schema:
         updates = []

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -79,6 +79,7 @@ def get_mock_rmwhub_data():
                 "traps_in_set": 2,
                 "trawl_path": None,
                 "share_with": ["Earth_Ranger"],
+                "when_updated_utc": "2025-03-14T16:38:12Z",
                 "traps": [
                     {
                         "trap_id": "test_trap_id_0",
@@ -115,6 +116,7 @@ def get_mock_rmwhub_data():
                 "traps_in_set": 2,
                 "trawl_path": None,
                 "share_with": ["Earth_Ranger"],
+                "when_updated_utc": "2025-03-14T16:38:12Z",
                 "traps": [
                     {
                         "trap_id": "test_trap_id_2",
@@ -151,6 +153,7 @@ def get_mock_rmwhub_data():
                 "traps_in_set": 2,
                 "trawl_path": None,
                 "share_with": ["Earth_Ranger"],
+                "when_updated_utc": "2025-03-14T16:38:12Z",
                 "traps": [
                     {
                         "trap_id": "test_trap_id_4",
@@ -187,6 +190,7 @@ def get_mock_rmwhub_data():
                 "traps_in_set": 2,
                 "trawl_path": None,
                 "share_with": ["Earth_Ranger"],
+                "when_updated_utc": "2025-03-14T16:38:12Z",
                 "traps": [
                     {
                         "trap_id": "test_trap_id_6",
@@ -223,6 +227,7 @@ def get_mock_rmwhub_data():
                 "traps_in_set": 1,
                 "trawl_path": None,
                 "share_with": ["Earth_Ranger"],
+                "when_updated_utc": "2025-03-14T16:38:12Z",
                 "traps": [
                     {
                         "trap_id": "test_trap_id_8",
@@ -253,6 +258,7 @@ def mock_rmwhub_items():
             share_with=["Earth_Ranger"],
             id="test_set_id_0",
             deployment_type="trawl",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_0",
@@ -289,6 +295,7 @@ def mock_rmwhub_items():
             share_with=["Earth_Ranger"],
             id="test_set_id_1",
             deployment_type="trawl",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_2",
@@ -325,6 +332,7 @@ def mock_rmwhub_items():
             share_with=["Earth_Ranger"],
             id="test_set_id_2",
             deployment_type="trawl",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_4",
@@ -361,6 +369,7 @@ def mock_rmwhub_items():
             share_with=["Earth_Ranger"],
             id="test_set_id_3",
             deployment_type="trawl",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_6",
@@ -397,6 +406,7 @@ def mock_rmwhub_items():
             share_with=["Earth_Ranger"],
             id="test_set_id_4",
             deployment_type="single",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_8",
@@ -426,6 +436,7 @@ def mock_rmwhub_items_update():
             share_with=["Earth_Ranger"],
             id="test_set_id_0",
             deployment_type="trawl",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_0",
@@ -449,6 +460,7 @@ def mock_rmwhub_items_update():
             share_with=["Earth_Ranger"],
             id="test_set_id_1",
             deployment_type="trawl",
+            when_updated_utc="2025-03-14T16:38:12Z",
             traps=[
                 Trap(
                     id="test_trap_id_1",

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -983,3 +983,93 @@ def mock_er_subjects_from_rmw():
             "url": "https://buoy.dev.pamdas.org/api/v1.0/subject/0931ddaa-770c-4bb4-9d66-b8106c17e043",
         },
     ]
+
+
+@pytest.fixture
+def mock_latest_observations():
+    return [
+        {
+            "id": "82d599d7-62f1-4620-bab4-0415fa8e6b4b",
+            "location": {"latitude": 34.472032, "longitude": -123.10975},
+            "created_at": "2024-10-09T17:00:54.182801-07:00",
+            "recorded_at": "2020-07-31T11:58:33-07:00",
+            "source": "7107445c-d883-423b-84d9-3525e7a37c8c",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 34.472032, "longitude": -123.10975},
+                        "device_id": "100",
+                        "last_updated": "2020-07-31T18:58:33+00:00",
+                    }
+                ],
+                "display_id": "9f9a88df5fbc",
+                "event_type": "smelts_buoy_deployment",
+                "radio_state": "online-gps",
+            },
+        },
+        {
+            "id": "207b5901-b3d7-4a04-8b2a-e3121b452ad3",
+            "location": {"latitude": 34.472032, "longitude": -123.10975},
+            "created_at": "2024-10-14T20:55:11.392267-07:00",
+            "recorded_at": "2020-07-31T11:58:33-07:00",
+            "source": "34ba3be1-b25e-411a-8d39-2a4b777bcbb1",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 34.472032, "longitude": -123.10975},
+                        "device_id": "device_100",
+                        "last_updated": "2020-07-31T18:58:33+00:00",
+                    }
+                ],
+                "display_id": "c242b9e4c9d9",
+                "event_type": "smelts_buoy_deployment",
+                "radio_state": "online-gps",
+            },
+        },
+        {
+            "id": "b404c5b9-bdd2-49f9-a036-80fab8393b6c",
+            "location": {"latitude": 41.876497, "longitude": -70.273052},
+            "created_at": "2024-10-14T20:55:00.331752-07:00",
+            "recorded_at": "2022-05-20T11:18:17-07:00",
+            "source": "a8db9e65-280b-4c5c-8d1d-caf568761e28",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 41.876497, "longitude": -70.273052},
+                        "device_id": "device_9909",
+                        "last_updated": "2022-05-20T18:18:17+00:00",
+                    }
+                ],
+                "display_id": "28d27646abdf",
+                "event_type": "smelts_buoy_subsea_data",
+                "radio_state": "online-gps",
+            },
+        },
+        {
+            "id": "112c4f7e-c17b-4e5a-8e3d-de576d1ad121",
+            "location": {"latitude": 41.876497, "longitude": -70.273052},
+            "created_at": "2024-10-09T17:00:50.031504-07:00",
+            "recorded_at": "2022-05-20T11:18:17-07:00",
+            "source": "823baa3b-47ea-4b08-bc55-cb6b666d220f",
+            "exclusion_flags": 0,
+            "observation_details": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {"latitude": 41.876497, "longitude": -70.273052},
+                        "device_id": "9909",
+                        "last_updated": "2022-05-20T18:18:17+00:00",
+                    }
+                ],
+                "display_id": "394f4fc71b46",
+                "event_type": "smelts_buoy_subsea_data",
+                "radio_state": "online-gps",
+            },
+        },
+    ]

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -108,8 +108,7 @@ async def test_rmwhub_search_hub(mocker, a_good_configuration):
         a_good_configuration.api_key, a_good_configuration.rmw_url
     )
     start_datetime_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    minute_interval = 5
-    response = await rmw_client.search_hub(start_datetime_str, minute_interval)
+    response = await rmw_client.search_hub(start_datetime_str)
 
     assert response == mock_response_text
 
@@ -130,7 +129,7 @@ async def test_rmwhub_search_hub_failure(mocker, a_good_configuration):
     )
     start_datetime_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     minute_interval = 60
-    response = await rmw_client.search_hub(start_datetime_str, minute_interval)
+    response = await rmw_client.search_hub(start_datetime_str)
 
     assert response == "Internal Server Error"
 

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -248,6 +248,17 @@ async def test_rmwhub_adapter_process_rmw_upload_update_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=mock_rmw_upload_response,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=mock_rmwhub_items_update),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_latest_observations",
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
         RmwSets(sets=mock_rmwhub_items_update), start_datetime_str

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -170,9 +170,17 @@ async def test_rmwhub_adapter_process_rmw_upload_insert_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=result,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[]), start_datetime_str
+        start_datetime_str
     )
 
     assert len(observations) == 0
@@ -187,9 +195,17 @@ async def test_rmwhub_adapter_process_rmw_upload_insert_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=mock_rmw_upload_response,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[mock_rmwhub_items[0]]), start_datetime_str
+        start_datetime_str
     )
     assert len(observations) == 5
     assert rmw_response["trap_count"] == 5
@@ -205,9 +221,17 @@ async def test_rmwhub_adapter_process_rmw_upload_insert_success(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value=mock_rmw_upload_response,
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[mock_rmwhub_items[0]]), start_datetime_str
+        start_datetime_str
     )
     assert len(observations) == 0
     assert rmw_response["trap_count"] == 0
@@ -221,6 +245,7 @@ async def test_rmwhub_adapter_process_rmw_upload_update_success(
     mock_rmwhub_items_update,
     mock_er_subjects_update,
     mock_rmw_upload_response,
+    mock_latest_observations,
 ):
     """
     Test RmwHubAdapter.process_rmw_upload update operations
@@ -261,7 +286,7 @@ async def test_rmwhub_adapter_process_rmw_upload_update_success(
     )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=mock_rmwhub_items_update), start_datetime_str
+        start_datetime_str
     )
     # There will be no new observsation for items originally from RMW
     # because the set ID has already been added.
@@ -298,9 +323,17 @@ async def test_rmwhub_adapter_process_rmw_upload_failure(
         "app.actions.rmwhub.RmwHubAdapter._upload_data",
         return_value={},
     )
+    mocker.patch(
+        "app.actions.rmwhub.RmwHubAdapter.search_own",
+        return_value=RmwSets(sets=[mock_rmwhub_items[0]]),
+    )
+    mocker.patch(
+        "app.actions.buoy.BuoyClient.get_gear",
+        return_value=[],
+    )
 
     observations, rmw_response = await rmw_adapter.process_rmw_upload(
-        RmwSets(sets=[mock_rmwhub_items[0]]), start_datetime_str
+        start_datetime_str
     )
     assert len(observations) == 0
     assert rmw_response == {}


### PR DESCRIPTION
### What does this PR do
Bug fix for RF-847. Use the `start_datetime_utc` param in `search_hub` from rmwHub to pull all data with updates since the start time. 

PR also include some bug fixes and changes from this PR: https://github.com/PADAS/gundi-integration-rmwhub/pull/20

Upload code is still commented out pending QA and tickets: RF-835 and RF-834. 

### Dev Validation
Local validation with the 5 minute sync operation test.ropeless.network site:
<img width="587" alt="Screenshot 2025-03-14 at 5 08 40 PM" src="https://github.com/user-attachments/assets/d847dac8-0c26-475a-954a-ba3f8914cdc8" />

No screenshot, but the validation done for the 24 hour sync pulled 247 observations including observations from upload code. 


### Relevant Links 
[RF-847](https://allenai.atlassian.net/browse/RF-847)


[RF-847]: https://allenai.atlassian.net/browse/RF-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ