### PR TITLE
Hot fix: Add correct datetime parsing to handle fractional seconds

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -54,7 +54,7 @@ async def action_pull_observations(
     integration, action_config: PullRmwHubObservationsConfiguration
 ):
     current_datetime = datetime.now(timezone.utc)
-    sync_interval_minutes = 5
+    sync_interval_minutes = 30
     start_datetime = current_datetime - timedelta(minutes=sync_interval_minutes)
     start_datetime_str = start_datetime.isoformat(timespec="seconds")
     end_datetime = current_datetime

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -103,27 +103,30 @@ async def action_pull_observations(
         )
 
         observations = []
-        if len(rmwSets.sets) != 0:
-            logger.info(
-                f"Processing updates from RMW Hub API...Number of gearsets returned: {len(rmwSets.sets)}"
-            )
-            observations = await rmw_adapter.process_rmw_download(
-                rmwSets, start_datetime_str, sync_interval_minutes
-            )
-            total_observations.extend(observations)
-        else:
-            await log_action_activity(
-                integration_id=integration.id,
-                action_id="pull_observations",
-                level=LogLevel.INFO,
-                title="No gearsets returned from RMW Hub API.",
-                data={
-                    "start_date_time": start_datetime_str,
-                    "end_date_time": end_datetime_str,
-                    "environment": str(environment),
-                },
-                config_data=action_config.dict(),
-            )
+        try:
+            if len(rmwSets.sets) != 0:
+                logger.info(
+                    f"Processing updates from RMW Hub API...Number of gearsets returned: {len(rmwSets.sets)}"
+                )
+                observations = await rmw_adapter.process_rmw_download(
+                    rmwSets, start_datetime_str, sync_interval_minutes
+                )
+                total_observations.extend(observations)
+            else:
+                await log_action_activity(
+                    integration_id=integration.id,
+                    action_id="pull_observations",
+                    level=LogLevel.INFO,
+                    title="No gearsets returned from RMW Hub API.",
+                    data={
+                        "start_date_time": start_datetime_str,
+                        "end_date_time": end_datetime_str,
+                        "environment": str(environment),
+                    },
+                    config_data=action_config.dict(),
+                )
+        except ValueError as e:
+            logger.error(f"Failed to process RMW Hub data: {str(e)}")
 
         # Upload changes from ER to RMW Hub
         rmw_response = {}

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,7 +1,7 @@
 # actions/handlers.py
-from enum import Enum
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Tuple
 
 from gundi_client_v2 import GundiClient
@@ -14,7 +14,7 @@ from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.gundi import send_observations_to_gundi
 from app.services.utils import find_config_for_action
 
-from .configurations import PullRmwHubObservationsConfiguration, AuthenticateConfig
+from .configurations import AuthenticateConfig, PullRmwHubObservationsConfiguration
 from .rmwhub import RmwHubAdapter
 
 logger = logging.getLogger(__name__)
@@ -53,12 +53,12 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
 async def action_pull_observations(
     integration, action_config: PullRmwHubObservationsConfiguration
 ):
-    current_datetime = datetime.now()
+    current_datetime = datetime.now(timezone.utc)
     sync_interval_minutes = 5
     start_datetime = current_datetime - timedelta(minutes=sync_interval_minutes)
-    start_datetime_str = start_datetime.strftime("%Y-%m-%d %H:%M:%S")
+    start_datetime_str = start_datetime.isoformat(timespec="seconds")
     end_datetime = current_datetime
-    end_datetime_str = end_datetime.strftime("%Y-%m-%d %H:%M:%S")
+    end_datetime_str = end_datetime.isoformat(timespec="seconds")
 
     # TODO: Create sub-actions for each destination
     total_observations = []
@@ -201,11 +201,11 @@ async def action_pull_observations_24_hour_sync(
 ):
 
     sync_interval_minutes = 1440  # 24 hours
-    current_datetime = datetime.now()
+    current_datetime = datetime.now(timezone.utc)
     start_datetime = current_datetime - timedelta(minutes=sync_interval_minutes)
-    start_datetime_str = start_datetime.strftime("%Y-%m-%d %H:%M:%S")
+    start_datetime_str = start_datetime.isoformat(timespec="seconds")
     end_datetime = current_datetime
-    end_datetime_str = end_datetime.strftime("%Y-%m-%d %H:%M:%S")
+    end_datetime_str = end_datetime.isoformat(timespec="seconds")
 
     # TODO: Create sub-actions for each destination
     total_observations = []

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -83,7 +83,11 @@ class Trap(BaseModel):
         Convert the datetime string to UTC.
         """
 
-        datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
+        try:
+            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
+        except ValueError:
+            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
+
         datetime_obj = datetime_obj.astimezone(pytz.utc)
         return datetime_obj
 
@@ -931,7 +935,7 @@ class RmwHubAdapter:
 
         datetime_obj = datetime.fromisoformat(datetime_str)
         datetime_obj = datetime_obj.astimezone(pytz.utc)
-        formatted_datetime = datetime_obj.strftime("%Y-%m-%dT%H:%M:%SZ")
+        formatted_datetime = datetime_obj.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
         return formatted_datetime
 
 

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dateparser import parse as parse_date
 from enum import Enum
 import hashlib
 from typing import List, Optional, Tuple
@@ -83,13 +84,12 @@ class Trap(BaseModel):
         Convert the datetime string to UTC.
         """
 
-        try:
-            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
-        except ValueError:
-            datetime_obj = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
+        naive_datetime_obj = parse_date(datetime_str)
+        utc_datetime_obj = naive_datetime_obj.replace(tzinfo=timezone.utc)
+        if not utc_datetime_obj:
+            raise ValueError(f"Unable to parse datetime string: {datetime_str}")
 
-        datetime_obj = datetime_obj.astimezone(pytz.utc)
-        return datetime_obj
+        return utc_datetime_obj
 
 
 class GearSet(BaseModel):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -69,9 +69,10 @@ async def test_handler_action_pull_observations(
         len(mock_rmw_observations) * len(a_good_connection.destinations)
     )
 
-    expected_start_datetime_str = (fixed_now - timedelta(minutes=5)).isoformat(
-        timespec="seconds"
-    )
+    sync_interval_minutes = 30
+    expected_start_datetime_str = (
+        fixed_now - timedelta(minutes=sync_interval_minutes)
+    ).isoformat(timespec="seconds")
 
     assert download_data_mock.call_count == len(a_good_connection.destinations)
     for call in download_data_mock.call_args_list:

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from app.actions.rmwhub import RmwSets
@@ -21,7 +23,7 @@ async def test_handler_action_pull_observations(
     """
     Test handler.action_pull_observations
     """
-
+    fixed_now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     items = mock_rmwhub_items
 
     mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
@@ -33,7 +35,8 @@ async def test_handler_action_pull_observations(
         "app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class
     )
     mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
-    mocker.patch(
+
+    download_data_mock = mocker.patch(
         "app.actions.rmwhub.RmwHubAdapter.download_data",
         return_value=(RmwSets(sets=items)),
     )
@@ -53,6 +56,8 @@ async def test_handler_action_pull_observations(
         "app.actions.handlers.get_er_token_and_site",
         return_value=("super_secret_token", "er.destination.com"),
     )
+    mock_datetime = mocker.patch("app.actions.handlers.datetime")
+    mock_datetime.now.return_value = fixed_now
 
     from app.actions.handlers import action_pull_observations
 
@@ -63,3 +68,12 @@ async def test_handler_action_pull_observations(
     assert action_response.get("observations_extracted") == (
         len(mock_rmw_observations) * len(a_good_connection.destinations)
     )
+
+    expected_start_datetime_str = (fixed_now - timedelta(minutes=5)).isoformat(
+        timespec="seconds"
+    )
+
+    assert download_data_mock.call_count == len(a_good_connection.destinations)
+    for call in download_data_mock.call_args_list:
+        args, kwargs = call
+        assert args[0] == expected_start_datetime_str

--- a/app/actions/tests/test_trap.py
+++ b/app/actions/tests/test_trap.py
@@ -1,0 +1,34 @@
+import pytest
+from datetime import datetime, timezone
+
+
+@pytest.mark.asyncio
+async def test_trap_convert_to_utc(mock_rmwhub_items):
+    """
+    Test trap.convert_to_utc
+    """
+
+    # Setup mock trap
+    mock_trap = mock_rmwhub_items[0].traps[0]
+
+    datetime_obj = datetime.now(timezone.utc)
+    datetime_with_seconds_str = datetime_obj.strftime("%Y-%m-%d %H:%M:%S")
+    parsed_datetime = mock_trap.convert_to_utc(datetime_with_seconds_str)
+    datetime_without_fractional = datetime_obj.replace(microsecond=0)
+
+    assert parsed_datetime
+    assert parsed_datetime == datetime_without_fractional
+    assert parsed_datetime.strftime("%Y-%m-%d %H:%M:%S") == datetime_with_seconds_str
+
+    # Test with datetime with fractional seconds
+    datetime_with_fractional_seconds_str = datetime_obj.strftime("%Y-%m-%d %H:%M:%S.%f")
+    parsed_datetime_with_fractional_seconds = mock_trap.convert_to_utc(
+        datetime_with_fractional_seconds_str
+    )
+
+    assert parsed_datetime_with_fractional_seconds
+    assert parsed_datetime_with_fractional_seconds == datetime_obj
+    assert (
+        parsed_datetime_with_fractional_seconds.strftime("%Y-%m-%d %H:%M:%S.%f")
+        == datetime_with_fractional_seconds_str
+    )

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 # Add your integration-specific dependencies here
 requests==2.28.2
-pytz==2021.3
+pytz==2022.1
+dateparser==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,8 @@ click==8.1.7
     #   uvicorn
 cryptography==43.0.3
     # via gcloud-aio-auth
+dateparser==1.1.1
+    # via -r requirements.in
 environs==9.5.0
     # via
     #   -r requirements-base.in
@@ -121,18 +123,26 @@ pytest-asyncio==0.21.2
     # via -r requirements-dev.in
 pytest-mock==3.12.0
     # via -r requirements-dev.in
+python-dateutil==2.9.0.post0
+    # via dateparser
 python-dotenv==1.0.1
     # via environs
 python-json-logger==2.0.7
     # via -r requirements-base.in
-pytz==2021.3
-    # via -r requirements.in
+pytz==2022.1
+    # via
+    #   -r requirements.in
+    #   dateparser
 redis==5.0.8
     # via -r requirements-base.in
+regex==2022.3.2
+    # via dateparser
 requests==2.28.2
     # via -r requirements.in
 respx==0.21.1
     # via gundi-client-v2
+six==1.17.0
+    # via python-dateutil
 sniffio==1.3.1
     # via
     #   anyio
@@ -152,6 +162,8 @@ typing-extensions==4.12.2
     #   multidict
     #   pydantic
     #   uvicorn
+tzlocal==5.3.1
+    # via dateparser
 urllib3==1.26.20
     # via requests
 uvicorn==0.23.2


### PR DESCRIPTION
Fix bug in production to handle fractional seconds in rmwHub Action Runner datetime parsing. 

Reported by Victor Garcia from Gundi:
https://nimblegravity.slack.com/archives/C08GFTN0D3N/p1742312414551209
Logs: https://gundiservice.org/connections/f163f5b8-e4a2-412a-877a-daf9044864ad/logs