### PR TITLE
fix: add timezone awareness for rmwhub search parameters

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,7 +1,7 @@
 # actions/handlers.py
-from enum import Enum
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Tuple
 
 from gundi_client_v2 import GundiClient
@@ -14,7 +14,7 @@ from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.gundi import send_observations_to_gundi
 from app.services.utils import find_config_for_action
 
-from .configurations import PullRmwHubObservationsConfiguration, AuthenticateConfig
+from .configurations import AuthenticateConfig, PullRmwHubObservationsConfiguration
 from .rmwhub import RmwHubAdapter
 
 logger = logging.getLogger(__name__)
@@ -198,11 +198,11 @@ async def action_pull_observations_24_hour_sync(
 ):
 
     sync_interval_minutes = 1440  # 24 hours
-    current_datetime = datetime.now()
+    current_datetime = datetime.now(timezone.utc)
     start_datetime = current_datetime - timedelta(minutes=sync_interval_minutes)
-    start_datetime_str = start_datetime.strftime("%Y-%m-%d %H:%M:%S")
+    start_datetime_str = start_datetime.isoformat(timespec="seconds")
     end_datetime = current_datetime
-    end_datetime_str = end_datetime.strftime("%Y-%m-%d %H:%M:%S")
+    end_datetime_str = end_datetime.isoformat(timespec="seconds")
 
     # TODO: Create sub-actions for each destination
     total_observations = []


### PR DESCRIPTION
# Description

This PR addresses the request for adding timezone awareness for the filters applied in the rmwhub requests. That should prevent inconsistencies in the returned data regarding not sending the timezone in the "datetime" string.

# Changes

```py
# current_datetime = datetime.now()
current_datetime = datetime.now(timezone.utc) # Will return the current datetime in UTC timezone with tzinfo set
start_datetime = current_datetime - timedelta(minutes=sync_interval_minutes)
# start_datetime_str = start_datetime.strftime("%Y-%m-%d %H:%M:%S")
start_datetime_str = start_datetime.isoformat(timespec="seconds") # Will return the datetime formatted according to ISO (without microseconds, only seconds)
end_datetime = current_datetime
# end_datetime_str = end_datetime.strftime("%Y-%m-%d %H:%M:%S")
end_datetime_str = end_datetime.isoformat(timespec="seconds") # Will return the datetime formatted according to ISO (without microseconds, only seconds)
```