### PR TITLE
Alter installation for pyjq.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,12 @@
 FROM python:3.10-slim AS baseimage
 
 # This command is for webhooks support
-RUN apt-get update && apt-get install -y autoconf automake libtool make python3-dev
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends autoconf automake libtool build-essential \
+    python3-dev \
+    && pip install pyjq \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
 # Add your integration-specific dependencies here
-requests==2.28.2
-pytz==2022.1
-dateparser==1.1.1
+requests==2.32.3
+pytz==2025.2
+dateparser==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ click==8.1.7
     #   uvicorn
 cryptography==43.0.3
     # via gcloud-aio-auth
-dateparser==1.1.1
+dateparser==1.2.1
     # via -r requirements.in
 environs==9.5.0
     # via
@@ -129,7 +129,7 @@ python-dotenv==1.0.1
     # via environs
 python-json-logger==2.0.7
     # via -r requirements-base.in
-pytz==2022.1
+pytz==2025.2
     # via
     #   -r requirements.in
     #   dateparser
@@ -137,7 +137,7 @@ redis==5.0.8
     # via -r requirements-base.in
 regex==2022.3.2
     # via dateparser
-requests==2.28.2
+requests==2.32.3
     # via -r requirements.in
 respx==0.21.1
     # via gundi-client-v2


### PR DESCRIPTION
This is to solve for successfully building and install pyjq. 

Use `--no-install-recommends` to reduce the image size, added `build-essential`, and included a cleanup step to remove unnecessary files.

I also updated the versions of `requests`, `pytz`, and `dateparser` to their latest versions.