### PR TITLE
RF-889: Duplicates being recorded in rmwHub

### DIFF
--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -684,7 +684,7 @@ class RmwHubAdapter:
             traps_to_gearsets_mapping_key = self._create_traps_gearsets_mapping_key(
                 [device.get("device_id") for device in devices]
             )
-            rmwhub_set_id = traps_to_gearsets_mapping.get(traps_to_gearsets_mapping_key)
+            rmw_gearset = traps_to_gearsets_mapping.get(traps_to_gearsets_mapping_key)
 
             if not rmwhub_set_id:
                 logger.error(
@@ -697,8 +697,6 @@ class RmwHubAdapter:
                     level=LogLevel.ERROR,
                 )
                 continue
-
-            rmw_gearset = set_id_to_gearset_mapping[rmwhub_set_id]
 
             updated_gearset = await self._create_rmw_update_from_er_subject(
                 subject, latest_observation, rmw_gearset

--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -87,7 +87,6 @@ class Trap(BaseModel):
 
         return utc_datetime_obj
 
-      
     def shift_update_time(self):
         """
         Shift the update time of the trap by 5 seconds.
@@ -101,7 +100,6 @@ class Trap(BaseModel):
             self.retrieved_datetime_utc = (
                 self.get_latest_update_time() + timedelta(seconds=5)
             ).isoformat()
-
 
 
 class GearSet(BaseModel):
@@ -275,7 +273,8 @@ class RmwHubAdapter:
         rmw_url: str,
         er_token: str,
         er_destination: str,
-        *args, **kwargs
+        *args,
+        **kwargs,
     ):
         self.integration_id = integration_id
         self.rmw_client = RmwHubClient(api_key, rmw_url)
@@ -462,17 +461,21 @@ class RmwHubAdapter:
 
         return observations
 
-    async def create_subject_latest_observation_mapping(self, er_subjects: List) -> Dict[str, Dict]:
+    async def create_subject_latest_observation_mapping(
+        self, er_subjects: List
+    ) -> Dict[str, Dict]:
         """
         Create a mapping of ER Subjects IDs to their latest observations.
         """
-        
+
         subject_id_to_latest_observation = {}
         for er_subject in er_subjects:
             subject_id = er_subject.get("id")
-            latest_observations = await self.er_client.get_latest_observations(subject_id, 1)
+            latest_observations = await self.er_client.get_latest_observations(
+                subject_id, 1
+            )
             subject_id_to_latest_observation[subject_id] = (
-            latest_observations[0] if latest_observations else {}
+                latest_observations[0] if latest_observations else {}
             )
         return subject_id_to_latest_observation
 
@@ -482,8 +485,7 @@ class RmwHubAdapter:
         """
         sorted_traps_ids = sorted(traps_ids)
         cleaned_traps_ids = [
-            RmwHubAdapter.clean_id_str(trap_id).lower().rstrip("#")
-            for trap_id in sorted_traps_ids
+            RmwHubAdapter.clean_id_str(trap_id) for trap_id in sorted_traps_ids
         ]
         "".join(cleaned_traps_ids)
         return "".join(cleaned_traps_ids)
@@ -506,8 +508,9 @@ class RmwHubAdapter:
 
         return traps_to_gearsets_mapping
 
-
-    def create_display_id_subject_mapping(self, er_subjects: List, subject_latest_observation_mapping: Dict) -> Dict[str, dict]:
+    def create_display_id_subject_mapping(
+        self, er_subjects: List, subject_latest_observation_mapping: Dict
+    ) -> Dict[str, dict]:
         """
         Create a mapping of display IDs to their corresponding Earthranger subjects.
         """
@@ -515,7 +518,9 @@ class RmwHubAdapter:
         for er_subject in er_subjects:
             subject_id = er_subject.get("id")
             latest_observation = subject_latest_observation_mapping.get(subject_id)
-            display_id = latest_observation.get("observation_details", {}).get("display_id")
+            display_id = latest_observation.get("observation_details", {}).get(
+                "display_id"
+            )
             if display_id:
                 display_id_to_er_subject_mapping[display_id] = er_subject
         return display_id_to_er_subject_mapping
@@ -546,25 +551,31 @@ class RmwHubAdapter:
             return 0, {}
 
         # Set of all traps ids in the RMW sets
-        rmw_trap_ids = {RmwHubAdapter.clean_id_str(trap.id).rstrip("#") for gearset in rmw_sets.sets for trap in gearset.traps}
-        
+        rmw_trap_ids = {
+            RmwHubAdapter.clean_id_str(trap.id)
+            for gearset in rmw_sets.sets
+            for trap in gearset.traps
+        }
+
         # Create utility mapping for the upload process
 
         # ER Subject ID to latest observation mapping
-        subject_id_to_latest_observation_mapping = await self.create_subject_latest_observation_mapping(
-            er_subjects
+        subject_id_to_latest_observation_mapping = (
+            await self.create_subject_latest_observation_mapping(er_subjects)
         )
-    
+
         # ER Subject's display ID to ER Subject mapping
         display_id_to_subject_mapping = self.create_display_id_subject_mapping(
             er_subjects, subject_id_to_latest_observation_mapping
         )
-        
+
         # RMW traps (concactenated) to their corresponding gear sets
         traps_to_gearsets_mapping = self.create_traps_gearsets_mapping(rmw_sets)
-        
+
         # RMW set ID to respective gear set
-        set_id_to_gearset_mapping = await self.create_set_id_to_gearset_mapping(rmw_sets.sets)
+        set_id_to_gearset_mapping = await self.create_set_id_to_gearset_mapping(
+            rmw_sets.sets
+        )
 
         # Iterate through er_subjects and determine what is an insert and what is an update to RmwHub
         # Based on the display ID existence on the RMW side
@@ -575,18 +586,33 @@ class RmwHubAdapter:
             if not subject_name:
                 logger.error(f"Subject ID {subject_id} has no name. No action.")
                 continue
-            
-            subject_latest_observation = subject_id_to_latest_observation_mapping.get(subject_id)
-            subject_display_id = subject_latest_observation.get("observation_details", {}).get("display_id")
-            
+
+            subject_latest_observation = subject_id_to_latest_observation_mapping.get(
+                subject_id
+            )
+            subject_display_id = subject_latest_observation.get(
+                "observation_details", {}
+            ).get("display_id")
+
+            devices = subject_latest_observation.get("observation_details", {}).get(
+                "devices"
+            )
+            traps_to_gearsets_mapping_key = self._create_traps_gearsets_mapping_key(
+                [device.get("device_id") for device in devices]
+            )
+            rmwhub_set_id = traps_to_gearsets_mapping.get(traps_to_gearsets_mapping_key)
+
             if subject_name.startswith("rmw"):
                 logger.info(
                     f"Subject ID {subject_name} originally from rmwHub. Skipped."
                 )
                 continue
-            
+
             # Use display_id for ER subjects to ensure uniqueness among gear sets
-            elif RmwHubAdapter.clean_id_str(subject_name).lower() in rmw_trap_ids:
+            elif (
+                RmwHubAdapter.clean_id_str(subject_name).lower() in rmw_trap_ids
+                and rmwhub_set_id
+            ):
                 er_updates.add(subject_display_id)
             else:
                 er_inserts.add(subject_display_id)
@@ -603,7 +629,12 @@ class RmwHubAdapter:
             logger.info(f"Subject ID {subject.get('name')} not found in RMW traps.")
 
             # Create new updates from ER data for upload to RMWHub, and collect set ID to update ER.
-            updated_gearset = await self._create_rmw_update_from_er_subject(subject)
+            subject_latest_observation = subject_id_to_latest_observation_mapping.get(
+                subject.get("id")
+            )
+            updated_gearset = await self._create_rmw_update_from_er_subject(
+                subject, subject_latest_observation
+            )
 
             if updated_gearset is None:
                 await log_action_activity(
@@ -622,15 +653,14 @@ class RmwHubAdapter:
                 )
             else:
                 # TODO: Check with Halley if this is needed
-                # num_new_observations += await self._create_put_er_set_id_observation(
-                #     subject, updated_gearset.id
-                # )
+                num_new_observations += await self._create_put_er_set_id_observation(
+                    subject, updated_gearset.id
+                )
                 updates.append(updated_gearset)
 
                 logger.info(
                     f"Processed new gear set for set ID {updated_gearset.id} from ER subject ID: {subject.get('id')}."
                 )
-
 
         # Handle updates to RMW
         for display_id in er_updates:
@@ -639,23 +669,27 @@ class RmwHubAdapter:
             logger.info(f"Subject ID {subject.get('name')} found in RMW traps.")
 
             # Get the latest observation for the subject
-            latest_observation = subject_id_to_latest_observation_mapping.get(subject_id)
+            latest_observation = subject_id_to_latest_observation_mapping.get(
+                subject_id
+            )
 
             if not latest_observation:
-                logger.error(f"Subject ID {subject.get('id')} has no latest observation.")
+                logger.error(
+                    f"Subject ID {subject.get('id')} has no latest observation."
+                )
                 continue
-            
-            devices = latest_observation.get("observation_details", {}).get("devices")                
-            
+
+            devices = latest_observation.get("observation_details", {}).get("devices")
+
             traps_to_gearsets_mapping_key = self._create_traps_gearsets_mapping_key(
                 [device.get("device_id") for device in devices]
             )
-            rmwhub_set_id = traps_to_gearsets_mapping.get(
-                traps_to_gearsets_mapping_key
-            )
+            rmwhub_set_id = traps_to_gearsets_mapping.get(traps_to_gearsets_mapping_key)
 
             if not rmwhub_set_id:
-                logger.error(f"RMW Set ID not found for subject ID {subject.get('id')}. No action.")
+                logger.error(
+                    f"RMW Set ID not found for subject ID {subject.get('id')}. No action."
+                )
                 log_action_activity(
                     integration_id=self.integration_id,
                     action_id="pull_observations",
@@ -667,7 +701,7 @@ class RmwHubAdapter:
             rmw_gearset = set_id_to_gearset_mapping[rmwhub_set_id]
 
             updated_gearset = await self._create_rmw_update_from_er_subject(
-                subject, rmw_gearset, latest_observation
+                subject, latest_observation, rmw_gearset
             )
 
             if updated_gearset is None:
@@ -688,9 +722,9 @@ class RmwHubAdapter:
                 )
             else:
                 # TODO: Check with Halley if this is needed
-                # num_new_observations += await self._create_put_er_set_id_observation(
-                #     subject, updated_gearset.id
-                # )
+                num_new_observations += await self._create_put_er_set_id_observation(
+                    subject, updated_gearset.id
+                )
                 updates.append(updated_gearset)
                 logger.info(
                     f"Processed update for gear set with set ID {updated_gearset.id} from ER subject ID: {subject['id']}."
@@ -699,7 +733,9 @@ class RmwHubAdapter:
         response = await self._upload_data(updates)
         if not updates:
             logger.info("No updates to upload to RMW Hub API.")
-        num_new_observations = len([trap.id for gearset in updates for trap in gearset.traps])
+        num_new_observations = len(
+            [trap.id for gearset in updates for trap in gearset.traps]
+        )
         return num_new_observations, response
 
     # TODO RF-752: Remove unecessary code when status updates are verified to be working through event
@@ -899,11 +935,14 @@ class RmwHubAdapter:
         return {}
 
     async def _create_rmw_update_from_er_subject(
-        self, er_subject: dict, rmw_gearset: GearSet = None, latest_observation: dict = None
+        self,
+        er_subject: dict,
+        latest_observation: dict = None,
+        rmw_gearset: GearSet = None,
     ) -> Optional[GearSet]:
         """
         Create new updates from ER data for upload to RMWHub.
-        
+
         :param er_subject: ER subject to create updates from
         :param rmw_gearset: RMW gear set to update (not required for new inserts)
         :param latest_observation: Latest observation for the subject (not required for new inserts)
@@ -937,26 +976,31 @@ class RmwHubAdapter:
         deployed = er_subject.get("is_active")
         additional_data = er_subject.get("additional", {})
 
-        trap_id_mapping = {
-            RmwHubAdapter.clean_id_str(trap.id).rstrip("#"): trap
-            for trap in rmw_gearset.traps
-        } if rmw_gearset else {}
+        trap_id_mapping = (
+            {RmwHubAdapter.clean_id_str(trap.id): trap for trap in rmw_gearset.traps}
+            if rmw_gearset
+            else {}
+        )
 
-        devices = latest_observation.get("observation_details", {}).get("devices") if latest_observation else additional_data.get("devices")
-        latest_observation_datetime = latest_observation.get("recorded_at") if latest_observation else None
+        devices = (
+            latest_observation.get("observation_details", {}).get("devices")
+            if latest_observation
+            else additional_data.get("devices")
+        )
+        latest_observation_datetime = (
+            latest_observation.get("recorded_at") if latest_observation else None
+        )
         for device in devices:
             # Use just the ID for the Trap ID if the gearset is originally from RMW
-            # TODO: Use subject.id instead of subject.name for the trap ID
-            # TODO: Determine the effects of this^ change on the download/upload process
             subject_name = er_subject.get("name")
             device_name = device.get("device_id")
-            cleaned_id = RmwHubAdapter.clean_id_str(device_name).rstrip("#")
+            cleaned_id = RmwHubAdapter.clean_id_str(device_name)
             trap_id = (
                 cleaned_id
                 if rmw_gearset and subject_name.startswith("rmw")
                 else "e_" + cleaned_id
             )
-            
+
             if not deployed and not rmw_gearset:
                 msg = f"This trap ({trap_id}) is not being deployed and still does not exist in RMW Hub, skipping."
                 log_action_activity(
@@ -967,18 +1011,34 @@ class RmwHubAdapter:
                 )
                 logger.warning(msg)
                 continue
-            
-            rmw_trap_datetime = latest_observation_datetime if latest_observation else device.get("last_updated") 
-            rmw_trap_datetime = self.convert_datetime_to_utc(rmw_trap_datetime) if rmw_trap_datetime else None
+
+            rmw_trap_datetime = (
+                latest_observation_datetime
+                if latest_observation
+                else device.get("last_updated")
+            )
+            rmw_trap_datetime = (
+                self.convert_datetime_to_utc(rmw_trap_datetime)
+                if rmw_trap_datetime
+                else None
+            )
             # deploy_datetime_utc is required, so in retrieve events, we will use the current deployed datetime
-            current_deployed_datetime = trap_id_mapping.get(RmwHubAdapter.clean_id_str(trap_id)).deploy_datetime_utc if not deployed else None
+            current_deployed_datetime = (
+                trap_id_mapping.get(
+                    RmwHubAdapter.clean_id_str(trap_id)
+                ).deploy_datetime_utc
+                if not deployed
+                else None
+            )
             traps.append(
                 Trap(
                     id=validate_id_length(trap_id),
                     sequence=1 if device.get("label") == "a" else 2,
                     latitude=device.get("location").get("latitude"),
                     longitude=device.get("location").get("longitude"),
-                    deploy_datetime_utc=rmw_trap_datetime if deployed else current_deployed_datetime,
+                    deploy_datetime_utc=rmw_trap_datetime
+                    if deployed
+                    else current_deployed_datetime,
                     surface_datetime_utc=rmw_trap_datetime if deployed else None,
                     retrieved_datetime_utc=None if deployed else rmw_trap_datetime,
                     status="deployed" if deployed else "retrieved",
@@ -998,7 +1058,7 @@ class RmwHubAdapter:
         else:
             set_id = rmw_gearset.id
             vessel_id = rmw_gearset.vessel_id
-        
+
         share_with = self.options.get("share_with", [])
         gear_set = GearSet(
             vessel_id=vessel_id,
@@ -1060,6 +1120,7 @@ class RmwHubAdapter:
             .removeprefix("rmw_")
             .removeprefix("e_")
             .removeprefix("edgetech_")
+            .rstrip("#")
             .lower()
         )
         return cleaned_str

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -294,7 +294,7 @@ async def test_rmwhub_adapter_process_upload_update_success(
     )
     mocker.patch(
         "app.actions.buoy.BuoyClient.get_source_provider",
-        return_value={"source_provider": "rmwhub"}
+        return_value={"source_provider": "rmwhub"},
     )
     mocker.patch(
         "app.actions.buoy.BuoyClient.create_v1_observation",
@@ -304,7 +304,7 @@ async def test_rmwhub_adapter_process_upload_update_success(
     observations, rmw_response = await rmw_adapter.process_upload(start_datetime_str)
     # There will be no new observsation for items originally from RMW
     # because the set ID has already been added.
-    assert observations == 0
+    assert observations == 1
     assert rmw_response
 
 
@@ -384,7 +384,7 @@ async def test_rmwhub_adapter_create_rmw_update_from_er_subject(
 
     # Test create UPDATE update (existing rmwHub gearset)
     gearset_update = await rmwadapter._create_rmw_update_from_er_subject(
-        mock_er_subjects[0], mock_rmwhub_items[0]
+        mock_er_subjects[0], rmw_gearset=mock_rmwhub_items[0]
     )
 
     assert gearset_update

--- a/scripts/duplicated_sets_finder_rmwhub.py
+++ b/scripts/duplicated_sets_finder_rmwhub.py
@@ -1,0 +1,290 @@
+import json
+import requests
+import os
+from datetime import datetime
+from collections import defaultdict
+
+# Get the directory where this script is located
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+COORDINATE_SETS_FILE = "coordinate_sets_count.json"
+DUPLICATES_FILE = "location_duplicates.json"
+
+# API Configuration
+FORMAT_VERSION = 0.1
+API_KEY = "018ffe73-baf6-7140-ab65-8a243c0ee02d"
+URL = "https://ropeless.network/api/search_own/"
+
+
+def search_all_deployed():
+    """
+    Search for all deployed gear using the search_own endpoint.
+
+    Returns:
+        dict: Dictionary containing all deployed sets
+    """
+    body = {
+        "api_key": API_KEY,
+        "format_version": FORMAT_VERSION,
+        "from_latitude": -90,
+        "to_latitude": 90,
+        "from_longitude": -180,
+        "to_longitude": 180,
+        "status": "deployed",
+    }
+
+    response = requests.post(URL, json=body)
+
+    if response.status_code != 200:
+        print(f"Error: {response.status_code} ({response.text})")
+        return None
+
+    data = response.json()
+
+    # Write raw response to file
+    raw_response_file = os.path.join(SCRIPT_DIR, "raw_search_own_api_response.json")
+    with open(raw_response_file, "w") as file:
+        json.dump(data, file, indent=4)
+    print(f"Raw API response written to {raw_response_file}")
+
+    sets = data.get("sets", [])
+
+    result = {"total_sets_found": len(sets), "sets": sets}
+
+    return result
+
+
+def find_location_duplicates(sets):
+    """
+    Find sets that are deployed at the exact same location.
+
+    Args:
+        sets (list): List of sets to analyze
+
+    Returns:
+        dict: Dictionary of location duplicates with string keys
+    """
+    # Group sets by location
+    location_groups = defaultdict(list)
+
+    for set_item in sets:
+        # Get the first deployed trap's location to represent the set's location
+        for trap in set_item.get("traps", []):
+            if trap.get("status") == "deployed":
+                lat = trap.get("latitude")
+                lon = trap.get("longitude")
+                if lat is not None and lon is not None:
+                    location_key = f"{lat},{lon}"
+                    location_groups[location_key].append(
+                        {
+                            "set_id": set_item.get("set_id"),
+                            "trap_id": trap.get("trap_id"),
+                            "deploy_datetime_utc": trap.get("deploy_datetime_utc"),
+                        }
+                    )
+                    break  # Only use the first deployed trap's location
+
+    # Filter for locations with multiple sets
+    duplicates = {
+        location: sets for location, sets in location_groups.items() if len(sets) > 1
+    }
+
+    return duplicates
+
+
+def search_by_coordinates(latitude, longitude):
+    """
+    Search for sets at a specific location using the search_own endpoint.
+
+    Args:
+        latitude (float): Latitude of the search location
+        longitude (float): Longitude of the search location
+
+    Returns:
+        dict: Dictionary containing the count of sets found and their details
+    """
+    body = {
+        "api_key": API_KEY,
+        "format_version": FORMAT_VERSION,
+        "from_latitude": latitude,
+        "to_latitude": latitude,
+        "from_longitude": longitude,
+        "to_longitude": longitude,
+        "status": "deployed",
+    }
+
+    response = requests.post(URL, json=body)
+
+    if response.status_code != 200:
+        print(f"Error: {response.status_code} ({response.text})")
+        return None
+
+    data = response.json()
+
+    # Write raw response to file
+    raw_response_file = os.path.join(SCRIPT_DIR, "raw_api_response.json")
+    with open(raw_response_file, "w") as file:
+        json.dump(data, file, indent=4)
+    print(f"Raw API response written to {raw_response_file}")
+
+    sets = data.get("sets", [])
+
+    result = {
+        "search_location": {
+            "from_latitude": latitude,
+            "to_latitude": latitude,
+            "from_longitude": longitude,
+            "to_longitude": longitude,
+        },
+        "total_sets_found": len(sets),
+        "sets": sets,
+    }
+
+    # Write results to file
+    with open(COORDINATE_SETS_FILE, "w") as file:
+        json.dump(result, file, indent=4)
+
+    print(f"\nFound {len(sets)} sets at exact location ({latitude}, {longitude})")
+    print(f"Results written to {COORDINATE_SETS_FILE}")
+
+    return result
+
+
+def write_duplicate_details(duplicates, output_file):
+    """
+    Write detailed information about duplicate locations to a file.
+
+    Args:
+        duplicates (dict): Dictionary of location duplicates
+        output_file (str): Path to the output file
+    """
+    detailed_output = {}
+
+    for location, sets in duplicates.items():
+        lat, lon = location.split(",")
+        detailed_output[location] = {
+            "latitude": float(lat),
+            "longitude": float(lon),
+            "number_of_sets": len(sets),
+            "sets": [
+                {
+                    "set_id": set_info["set_id"],
+                    "trap_id": set_info["trap_id"],
+                    "deploy_datetime_utc": set_info["deploy_datetime_utc"],
+                }
+                for set_info in sets
+            ],
+        }
+
+    with open(output_file, "w") as file:
+        json.dump(detailed_output, file, indent=4)
+
+
+def main():
+    """Main function to run the coordinate search or find location duplicates"""
+    # Check if coordinates are provided
+
+    # leo's location 1
+    # latitude = 20.12232
+    # longitude = -98.73646
+
+    # leo's location 2
+    # latitude = 19.28666
+    # longitude = -99.66275
+
+    # Coordinates from the duplicated trap
+    # latitude = 40.5546611
+    # longitude = -70.582792
+
+    # if latitude and longitude:
+    #    coordinates_provided = True
+    # else:
+    coordinates_provided = False
+
+    if coordinates_provided:
+        print(f"Searching for sets at exact location ({latitude}, {longitude})")
+        result = search_by_coordinates(latitude, longitude)
+
+        if result:
+            print("\nSearch Results:")
+            print(f"Total sets found: {result['total_sets_found']}")
+            print(f"Results saved to {COORDINATE_SETS_FILE}")
+    else:
+        print("No coordinates provided. Searching for all deployed gear...")
+        result = search_all_deployed()
+
+        if result:
+            print(f"\nFound {result['total_sets_found']} deployed sets")
+            duplicates = find_location_duplicates(result["sets"])
+
+            # Calculate unique sets after removing duplicates
+            total_duplicate_sets = sum(len(sets) for sets in duplicates.values())
+            total_unique_locations = len(duplicates)
+            remaining_sets = result["total_sets_found"] - (
+                total_duplicate_sets - total_unique_locations
+            )
+
+            print(f"\nFound {len(duplicates)} locations with multiple deployed sets:")
+            print("\nSummary of duplicate locations:")
+            print(
+                "Location (Lat, Lon) | Number of Sets | Example Trap ID | First Deployed"
+            )
+            print("-" * 80)
+
+            for location, sets in duplicates.items():
+                lat, lon = location.split(",")
+                # Get the first trap ID as an example
+                example_trap_id = sets[0]["set_id"]
+                # Get the earliest deployment date
+                deploy_dates = [
+                    set_info["deploy_datetime_utc"]
+                    for set_info in sets
+                    if set_info["deploy_datetime_utc"]
+                ]
+                first_deployed = min(deploy_dates) if deploy_dates else "Unknown"
+                print(
+                    f"({lat}, {lon}) | {len(sets)} | {example_trap_id} | {first_deployed}"
+                )
+
+            print("\nSummary of duplicates:")
+            print(f"Total sets found: {result['total_sets_found']}")
+            print(f"Total duplicate sets: {total_duplicate_sets}")
+            print(f"Unique locations with duplicates: {total_unique_locations}")
+            print(
+                f"Sets that would be removed: {total_duplicate_sets - total_unique_locations}"
+            )
+            print(f"Sets remaining after removing duplicates: {remaining_sets}")
+
+            # Write detailed information to file
+            write_duplicate_details(duplicates, DUPLICATES_FILE)
+            print(f"\nDetailed information saved to {DUPLICATES_FILE}")
+
+
+if __name__ == "__main__":
+    main()
+
+# ! Example
+#   "vessel_id": "74218a3d-08d5-4fcd-a71e-fe85c81467d3",
+#   "set_id": "188bd1f6-972a-4ce2-be3b-129b74b6ee79",
+#   "deployment_type": "single",
+#   "traps_in_set": 1,
+#   "trawl_path": "",
+#   "share_with": [
+#     "Earth Ranger"
+#   ],
+#   "traps": [
+#     {
+#       "trap_id": "e_testestestestestestestestestestestest",
+#       "sequence": 0,
+#       "latitude": -90,
+#       "longitude": -180,
+#       "deploy_datetime_utc": "2025-01-07T21:44:57.627000Z",
+#       "surface_datetime_utc": "2025-01-07T21:44:57.627000Z",
+#       "retrieved_datetime_utc": "2025-03-31T23:54:35.256000Z",
+#       "status": "retrieved",
+#       "accuracy": "string",
+#       "release_type": "none",
+#       "is_on_end": true
+#     }
+#   ],
+#   "when_updated_utc": "2025-03-31T23:54:35.256000Z"
+# }


### PR DESCRIPTION
### What does this PR do
Bug fixes for RF-889 duplicates uploaded to rmwHub from rmwHub Action Runner Sync operation. Fixes include:
- check if the concatenated device IDs have already been added as a gearset to rmwHub
- pass the latest observation to the create_rmw_update_from_er_subject function
- uncomment push set ID observations

### Dev Validation
Steps:
1. Send 1 observation creating a gearset with a single device
<img width="531" alt="Screenshot 2025-04-17 at 9 31 56 AM" src="https://github.com/user-attachments/assets/ee61e9f1-de24-4d3f-9753-214374bdf51d" />

2. Run rmwHub Action Runner sync
3. Validate single gearset is in rmwHub
<img width="688" alt="Screenshot 2025-04-17 at 9 31 47 AM" src="https://github.com/user-attachments/assets/d45ac6be-2c50-4515-883e-0cb69da41f1c" />

4. Send 2 observations creating a gearset with 2 devices (including the device in step 1)
<img width="546" alt="Screenshot 2025-04-17 at 9 33 00 AM" src="https://github.com/user-attachments/assets/1345f9d2-a5fc-4e88-8f11-d5a675264ee2" />

5. Run rmwHub Action Runner sync
6. Validate that single gearset as well as trawl gearset is in rmwHub
<img width="579" alt="Screenshot 2025-04-17 at 9 35 44 AM" src="https://github.com/user-attachments/assets/97d397b1-c581-4911-ab6f-d8a2c351f912" />

7. Send 1 observation updating the single device gearset
8. Run rmwHub sync
9. Validate there are no duplicates in rmwHub
10. Send 2 observations updating the trawl gearset
11. Run rmwHub sync
12. Validate there are no duplicates in rmwHub

### Relevant Links 
[RF-889](https://allenai.atlassian.net/browse/RF-889)

[RF-889]: https://allenai.atlassian.net/browse/RF-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ