### PR TITLE
Add logging for updates to rmwHub. Remove sending update to rmwhub

### DIFF
--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -690,7 +690,7 @@ class RmwHubAdapter:
                 logger.error(
                     f"RMW Set ID not found for subject ID {subject.get('id')}. No action."
                 )
-                log_action_activity(
+                await log_action_activity(
                     integration_id=self.integration_id,
                     action_id="pull_observations",
                     title=f"RMW Set ID not found for subject ID {subject.get('id')}. No action.",
@@ -728,7 +728,13 @@ class RmwHubAdapter:
                     f"Processed update for gear set with set ID {updated_gearset.id} from ER subject ID: {subject['id']}."
                 )
 
-        response = await self._upload_data(updates)
+        # Commented out due to RF-889
+        # response = await self._upload_data(updates)
+        for update in updates:
+            logger.info(
+                f"Uploading gear set with set ID {update.id} to RMW Hub API. Update: {json.dumps(update.dict(), indent=2)}"
+            )
+        response = {}
         if not updates:
             logger.info("No updates to upload to RMW Hub API.")
         num_new_observations = len(
@@ -859,7 +865,8 @@ class RmwHubAdapter:
 
         display_id_hash = hashlib.sha256(str(set_id).encode()).hexdigest()[:12]
         is_active = er_subject.get("is_active")
-        source_provider = await self.er_client.get_source_provider(er_subject.get("id"))
+        # Commented out for RF-889
+        # source_provider = await self.er_client.get_source_provider(er_subject.get("id"))
 
         observations = []
         for device in er_subject.get("additional").get("devices"):
@@ -893,9 +900,13 @@ class RmwHubAdapter:
         # Send observations to Gundi v1 Sensors API
         created = 0
         for observation in observations:
-            created += await self.er_client.create_v1_observation(
-                source_provider, observation
+            logger.info(
+                f"Creating observation for Subject Name: {observation['name']} with rmwHub Set ID {observation['additional'].get('rmwhub_set_id')}."
             )
+            # Commented out for bug RF-889
+            # created += await self.er_client.create_v1_observation(
+            #     source_provider, observation
+            # )
 
         return created
 

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -217,7 +217,8 @@ async def test_rmwhub_adapter_process_upload_insert_success(
 
     observations, rmw_response = await rmw_adapter.process_upload(start_datetime_str)
     assert observations == 5
-    assert rmw_response["trap_count"] == 5
+    # Commented out for bug RF-889
+    # assert rmw_response["trap_count"] == 5
 
     # Test handle ER upload success with ER Subjects from RMW
     data = mock_er_subjects_from_rmw
@@ -241,7 +242,8 @@ async def test_rmwhub_adapter_process_upload_insert_success(
 
     observations, rmw_response = await rmw_adapter.process_upload(start_datetime_str)
     assert observations == 0
-    assert rmw_response["trap_count"] == 0
+    # Commented out for bug RF-889
+    # assert rmw_response["trap_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -305,7 +307,8 @@ async def test_rmwhub_adapter_process_upload_update_success(
     # There will be no new observsation for items originally from RMW
     # because the set ID has already been added.
     assert observations == 1
-    assert rmw_response
+    # Commented out for bug RF-889
+    # assert rmw_response
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?
Add logging for updates to rmwHub as well as set ID observations for gearsets uploaded to rmwHub. Remove sending updates to rmwHub. 

### Relevant Links
[RF-893](https://allenai.atlassian.net/browse/RF-893?atlOrigin=eyJpIjoiODhiNzVkOTY0YmJlNDQxZWExZDk5MDc4YmUzMzgxMGEiLCJwIjoiaiJ9)

### Dev Validation
<img width="958" alt="Screenshot 2025-04-17 at 1 21 05 PM" src="https://github.com/user-attachments/assets/080e1a01-5d65-4d0e-828c-a07d2da1273f" />


[RF-893]: https://allenai.atlassian.net/browse/RF-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ