### PR TITLE
Added start_date to filter subjects by last 30m and changed test

### DIFF
--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -401,7 +401,7 @@ class RmwHubAdapter:
 
         # Download Data from ER for the same time interval as RmwHub
         # TODO: Only download recent updates from ER
-        er_subjects = await self.er_client.get_er_subjects()
+        er_subjects = await self.er_client.get_er_subjects(start_datetime=start_datetime)
 
         # Create maps of er_subject_names and rmw_trap_ids/set_ids
         # RMW trap IDs would be in the subject name

--- a/app/actions/tests/test_rmwhub.py
+++ b/app/actions/tests/test_rmwhub.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import json
 from unittest.mock import AsyncMock
+from app.actions.buoy import BuoyClient
 import pytest
 import pytz
 
@@ -46,8 +47,9 @@ async def test_rmw_adapter_process_download(
     """
 
     # Setup mock_rmwhub_client
-    mocker.patch(
-        "app.actions.buoy.BuoyClient.get_er_subjects",
+    mocker.patch.object(
+        BuoyClient,
+        "get_er_subjects",
         return_value=[],
     )
 
@@ -91,6 +93,7 @@ async def test_rmw_adapter_process_download(
         rmw_sets, start_datetime, minute_interval
     )
 
+    BuoyClient.get_er_subjects.assert_called_once_with(start_datetime=start_datetime)
     assert len(observations) == num_gearsets * num_traps
 
 


### PR DESCRIPTION
This PR aims to solve issue [reported on gundi logs](https://gundiservice.org/connections/f163f5b8-e4a2-412a-877a-daf9044864ad/logs).

`/subjects/` request is timing out because no params for time filtering were being added when requesting resources.

* Adds param `start_datetime` when executing `get_er_subjects()`;
* Adds proper unit test assertion;