### PR TITLE
Changed filter on looking for updated subjects.

### DIFF
--- a/app/actions/rmwhub.py
+++ b/app/actions/rmwhub.py
@@ -405,7 +405,8 @@ class RmwHubAdapter:
         return list(self.er_client._get(path = "subjects", params = {
             "include_inactive": True,
             "include_details": True,
-            "position_updated_since": start_datetime
+            "updated_since": start_datetime,
+            "subject_subtypes": "ropeless_buoy_device"
         }))
 
     async def process_upload(self, start_datetime: datetime) -> Tuple[List, dict]:
@@ -556,7 +557,6 @@ class RmwHubAdapter:
 
         :param er_subject: ER subject to create updates from
         :param rmw_gearset: RMW gear set to update (not required for new inserts)
-        :param latest_observation: Latest observation for the subject (not required for new inserts)
         """
 
         deployed = er_subject.get('is_active')


### PR DESCRIPTION
This pull request makes updates to the `rmwhub` module to refine the handling of ER subjects and simplify method parameters. The changes focus on improving the filtering of subjects and streamlining the code for creating updates.

### Refinements to ER subject handling:

* [`app/actions/rmwhub.py`](diffhunk://#diff-96c8ac38d38e8d3ec400bb866cf070d2515c47e536d8a31085c74822f9715563L408-R409): Updated the `get_er_subjects` method to use the `updated_since` parameter instead of `position_updated_since` and added a new filter for `subject_subtypes` with the value `"ropeless_buoy_device"`. This enhances the specificity of retrieved subjects.

### Simplification of method parameters:

* [`app/actions/rmwhub.py`](diffhunk://#diff-96c8ac38d38e8d3ec400bb866cf070d2515c47e536d8a31085c74822f9715563L559): Removed the unnecessary `latest_observation` parameter from the `_create_rmw_update_from_er_subject` method, simplifying the method signature.