### PR TITLE
feat: improve trap comparison logic to check device ID and location m…

### DIFF
--- a/app/actions/rmwhub/adapter.py
+++ b/app/actions/rmwhub/adapter.py
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 # we don't duplicate the literal throughout the file.
 RMWHUB_MANUFACTURER = "rmwhub"
 
+# Tolerance in degrees for comparing geographic coordinates when checking if
+# a device location has changed. 0.0001 degrees is approximately 11 meters
+# at the equator (1 degree ≈ 111 km), which accounts for minor GPS drift
+# and floating-point precision differences while still detecting meaningful
+# location changes.
+LOCATION_TOLERANCE_DEGREES = 0.0001
+
 
 def is_valid_uuid(uuid_string):
     try:
@@ -195,8 +202,8 @@ class RmwHubAdapter:
                         # Check if location matches (using small tolerance for floating point comparison)
                         location_matches = (
                             er_device.location and
-                            abs(er_device.location.latitude - trap.latitude) < 0.0001 and
-                            abs(er_device.location.longitude - trap.longitude) < 0.0001
+                            abs(er_device.location.latitude - trap.latitude) < LOCATION_TOLERANCE_DEGREES and
+                            abs(er_device.location.longitude - trap.longitude) < LOCATION_TOLERANCE_DEGREES
                         )
                         
                         if status_matches and location_matches:


### PR DESCRIPTION
This pull request improves the trap processing logic in the `process_download` method of `app/actions/rmwhub/adapter.py` by making the status and location matching more precise and efficient. The main changes focus on more accurately determining when a trap should be skipped based on its correspondence with EarthRanger devices.

Enhancements to trap-device matching:

* Added a mapping from `device_id` to device for quick lookup, improving efficiency when checking traps against EarthRanger gear devices.
* Updated the logic to check both status and location matches between traps and EarthRanger devices, using a small tolerance for floating point location comparison to avoid skipping traps with minor coordinate differences.
* Improved logging to provide clearer information on why traps are being skipped or processed, including details about status and location matching.