### PR TITLE
feat: change sync interval from 3 to 2 minutes

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -167,7 +167,7 @@ async def handle_upload(
 
 
 @activity_logger()
-@crontab_schedule("*/3 * * * *")  # Run every 3 minutes
+@crontab_schedule("*/2 * * * *")  # Run every 2 minutes
 async def action_pull_observations(
     integration, action_config: PullRmwHubObservationsConfiguration
 ):


### PR DESCRIPTION
## Summary
- Change `action_pull_observations` crontab schedule from `*/3 * * * *` to `*/2 * * * *`

## Test plan
- [ ] Deploy to staging and confirm the action runs every 2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)