### PR TITLE
fix: normalize UUID casing in gear payload to ER

### DIFF
--- a/app/actions/rmwhub/adapter.py
+++ b/app/actions/rmwhub/adapter.py
@@ -482,7 +482,13 @@ class RmwHubAdapter:
             device_additional_data = trap.dict()
 
             device = {
-                "device_id": trap.id,
+                # Normalize to lowercase: RMW Hub can return the same UUID with
+                # inconsistent casing for a set vs. its trap (e.g. set_id uppercase,
+                # trap_id lowercase). ER keys the subject off set_id and the
+                # subjectsource off device_id, so mismatched casing leaves the subject
+                # orphaned (inactive) from an active subjectsource. Internal dedup
+                # already lowercases all ids, so the payload must match.
+                "device_id": str(trap.id).lower(),
                 "last_deployed": last_deployed,
                 "last_updated": last_updated,
                 "recorded_at": recorded_at,
@@ -504,7 +510,7 @@ class RmwHubAdapter:
         payload = {
             "deployment_type": deployment_type,
             "manufacturer_name": "RMWHub",
-            "set_id": gearset.id,
+            "set_id": str(gearset.id).lower(),
             "devices_in_set": len(devices),
             "devices": devices,
         }

--- a/app/actions/tests/test_rmwhub_adapter.py
+++ b/app/actions/tests/test_rmwhub_adapter.py
@@ -1099,6 +1099,40 @@ class TestRmwHubAdapter:
         assert device["device_status"] == "deployed"
         assert result["initial_deployment_date"] == "2023-09-15T14:30:00+00:00"
 
+    def test_create_gear_payload_normalizes_id_casing(self, adapter):
+        """RMW Hub can return the same UUID with different casing for set vs. trap.
+        Both set_id and device_id must be lowercased so ER links the subject to its
+        subjectsource instead of orphaning an inactive subject."""
+        uuid = "6e451c36-38eb-463c-8c70-31d0121f46aa"
+        trap = Trap(
+            id=uuid,  # lowercase
+            sequence=1,
+            latitude=41.771908883867766,
+            longitude=-70.50338133238256,
+            deploy_datetime_utc="2026-06-29T20:31:37Z",
+            surface_datetime_utc=None,
+            retrieved_datetime_utc=None,
+            status="deployed",
+            accuracy="gps",
+            release_type="none",
+            is_on_end=True,
+        )
+        gearset = GearSet(
+            vessel_id="vessel_001",
+            id=uuid.upper(),  # uppercase — same UUID, different case
+            deployment_type="single",
+            traps_in_set=1,
+            trawl_path={},
+            share_with=[],
+            when_updated_utc="2026-06-29T20:31:37Z",
+            traps=[trap],
+        )
+
+        result = adapter._create_gear_payload_from_gearset(gearset, [trap], "deployed")
+
+        assert result["set_id"] == uuid
+        assert result["devices"][0]["device_id"] == uuid
+
     def test_create_gear_payload_from_gearset_deployed_uses_deploy_time_when_gearset_unchanged(self, adapter):
         """When when_updated_utc is missing or not after deploy, last_updated/recorded_at stay at deploy time."""
         trap = Trap(


### PR DESCRIPTION
## Problem

Seen twice now: gear from RMW Hub shows up in ER where the `set_id` and the device/trap id are the **same UUID differing only in casing** — e.g. `trap_id=6e451c36-38eb-463c-8c70-31d0121f46aa`, `set=6E451C36-38EB-463C-8C70-31D0121F46AA`. The result is a **subject marked inactive** while its **subjectsource is active and connected** — orphaned.

## Root cause

RMW Hub's `search_hub` can return the same UUID with inconsistent casing for a single-trap deployment (set_id vs trap_id). The adapter is internally consistent — every dedup/lookup lowercases ids — but `_create_gear_payload_from_gearset` passed both ids to the Buoy/Gear API **verbatim** (`adapter.py:485`, `:507`). ER keys the subject off `set_id` and the subjectsource off `device_id`, so the two casings fail to reconcile as one object.

## Fix

Lowercase `device_id` and `set_id` in the gear payload so it matches the adapter's internal (already-lowercased) representation. Targeted to the download -> ER direction; the upload -> RMW Hub path (which builds `GearSet`/`Trap` from ER ids) is deliberately left untouched.

## Tests

Added `test_create_gear_payload_normalizes_id_casing` reproducing the exact reported ids (same UUID, set uppercase / trap lowercase). Full adapter suite: **66 passed, 2 skipped**.

## Notes

- Fixes new syncs going forward only. Gear already in ER with an uppercase subject id from a prior sync won't self-heal and may need manual cleanup in ER.

🤖 Generated with [Claude Code](https://claude.com/claude-code)