### PR TITLE
fix: normalize release_type casing before posting gear to Buoy API

### DIFF
--- a/app/actions/rmwhub/adapter.py
+++ b/app/actions/rmwhub/adapter.py
@@ -496,7 +496,7 @@ class RmwHubAdapter:
             # Lowercase release_type: the Buoy API choices are lowercase
             # (timed/acoustic/galvanic) but RMW Hub sends inconsistent casing
             # (e.g. "Acoustic"), which gets the whole gearset payload rejected with a 400.
-            release_type = (trap.release_type or "").lower()
+            release_type = (trap.release_type or "").strip().lower()
             if release_type and release_type != "none":
                 device["release_type"] = release_type
             devices.append(device)

--- a/app/actions/rmwhub/adapter.py
+++ b/app/actions/rmwhub/adapter.py
@@ -31,10 +31,6 @@ LOCATION_TOLERANCE_DEGREES = 0.0001
 # Page size for iterating over gears in EarthRanger.
 ER_GEAR_PAGE_SIZE = 500
 
-# Release types accepted by the Buoy API (lowercase). Any other value in a payload
-# is rejected with a 400, which fails the entire gearset.
-VALID_RELEASE_TYPES = {"timed", "acoustic", "galvanic"}
-
 
 def _ensure_tz_utc(dt_str: str) -> str:
     """Normalize an ISO 8601 timestamp string to UTC and return it as ISO.
@@ -497,18 +493,12 @@ class RmwHubAdapter:
                 },
                 "device_additional_data": device_additional_data
             }
-            # Normalize release_type: the Buoy API only accepts lowercase values
-            # (timed/acoustic/galvanic). RMW Hub sends inconsistent casing (e.g. "Acoustic"),
-            # which gets the whole gearset payload rejected with a 400. Unknown values are
-            # dropped from the payload; the raw value is still in device_additional_data.
+            # Lowercase release_type: the Buoy API choices are lowercase
+            # (timed/acoustic/galvanic) but RMW Hub sends inconsistent casing
+            # (e.g. "Acoustic"), which gets the whole gearset payload rejected with a 400.
             release_type = (trap.release_type or "").lower()
-            if release_type in VALID_RELEASE_TYPES:
+            if release_type and release_type != "none":
                 device["release_type"] = release_type
-            elif release_type and release_type != "none":
-                logger.warning(
-                    "Trap %s has unsupported release_type %r; omitting it from the Buoy payload",
-                    trap.id, trap.release_type,
-                )
             devices.append(device)
         
         # Determine deployment type

--- a/app/actions/rmwhub/adapter.py
+++ b/app/actions/rmwhub/adapter.py
@@ -31,6 +31,10 @@ LOCATION_TOLERANCE_DEGREES = 0.0001
 # Page size for iterating over gears in EarthRanger.
 ER_GEAR_PAGE_SIZE = 500
 
+# Release types accepted by the Buoy API (lowercase). Any other value in a payload
+# is rejected with a 400, which fails the entire gearset.
+VALID_RELEASE_TYPES = {"timed", "acoustic", "galvanic"}
+
 
 def _ensure_tz_utc(dt_str: str) -> str:
     """Normalize an ISO 8601 timestamp string to UTC and return it as ISO.
@@ -493,8 +497,18 @@ class RmwHubAdapter:
                 },
                 "device_additional_data": device_additional_data
             }
-            if trap.release_type and trap.release_type != "none":
-                device["release_type"] = trap.release_type 
+            # Normalize release_type: the Buoy API only accepts lowercase values
+            # (timed/acoustic/galvanic). RMW Hub sends inconsistent casing (e.g. "Acoustic"),
+            # which gets the whole gearset payload rejected with a 400. Unknown values are
+            # dropped from the payload; the raw value is still in device_additional_data.
+            release_type = (trap.release_type or "").lower()
+            if release_type in VALID_RELEASE_TYPES:
+                device["release_type"] = release_type
+            elif release_type and release_type != "none":
+                logger.warning(
+                    "Trap %s has unsupported release_type %r; omitting it from the Buoy payload",
+                    trap.id, trap.release_type,
+                )
             devices.append(device)
         
         # Determine deployment type

--- a/app/actions/tests/test_rmwhub_adapter.py
+++ b/app/actions/tests/test_rmwhub_adapter.py
@@ -1166,7 +1166,7 @@ class TestRmwHubAdapter:
             ("Galvanic", "galvanic"),
         ],
     )
-    def test_create_gear_payload_normalizes_release_type_casing(self, adapter, raw_release_type, expected):
+    def test_create_gear_payload_lowercases_release_type(self, adapter, raw_release_type, expected):
         """release_type is lowercased so the Buoy API ChoiceField accepts it (400 otherwise)."""
         gearset, trap = self._make_gearset_with_release_type(raw_release_type)
 
@@ -1174,9 +1174,9 @@ class TestRmwHubAdapter:
 
         assert result["devices"][0]["release_type"] == expected
 
-    @pytest.mark.parametrize("raw_release_type", ["none", "None", "", None, "manual", "unknown-type"])
-    def test_create_gear_payload_omits_unsupported_release_type(self, adapter, raw_release_type):
-        """Unsupported/none release types are omitted so the whole gearset isn't rejected."""
+    @pytest.mark.parametrize("raw_release_type", ["none", "None", "NONE", "", None])
+    def test_create_gear_payload_omits_none_release_type(self, adapter, raw_release_type):
+        """Empty/none release types are omitted from the payload."""
         gearset, trap = self._make_gearset_with_release_type(raw_release_type)
 
         result = adapter._create_gear_payload_from_gearset(gearset, [trap], "deployed")
@@ -1334,7 +1334,7 @@ class TestRmwHubAdapter:
             retrieved_datetime_utc=None,
             status="deployed",
             accuracy="gps",
-            release_type="galvanic",
+            release_type="manual",
             is_on_end=False
         )
         trap2 = Trap(
@@ -1372,7 +1372,7 @@ class TestRmwHubAdapter:
         assert result["devices"][1]["recorded_at"] == "2023-09-15T14:35:00+00:00"
         
         # Check release_type handling
-        assert result["devices"][0]["release_type"] == "galvanic"
+        assert result["devices"][0]["release_type"] == "manual"
         assert result["devices"][1]["release_type"] == "timed"
 
     def test_create_gear_payload_from_gearset_release_type_none(self, adapter):

--- a/app/actions/tests/test_rmwhub_adapter.py
+++ b/app/actions/tests/test_rmwhub_adapter.py
@@ -1164,6 +1164,8 @@ class TestRmwHubAdapter:
             ("ACOUSTIC", "acoustic"),
             ("timed", "timed"),
             ("Galvanic", "galvanic"),
+            (" Acoustic ", "acoustic"),  # whitespace-padded values are stripped
+            ("timed ", "timed"),
         ],
     )
     def test_create_gear_payload_lowercases_release_type(self, adapter, raw_release_type, expected):
@@ -1174,7 +1176,7 @@ class TestRmwHubAdapter:
 
         assert result["devices"][0]["release_type"] == expected
 
-    @pytest.mark.parametrize("raw_release_type", ["none", "None", "NONE", "", None])
+    @pytest.mark.parametrize("raw_release_type", ["none", "None", "NONE", "", None, " none ", "   "])
     def test_create_gear_payload_omits_none_release_type(self, adapter, raw_release_type):
         """Empty/none release types are omitted from the payload."""
         gearset, trap = self._make_gearset_with_release_type(raw_release_type)

--- a/app/actions/tests/test_rmwhub_adapter.py
+++ b/app/actions/tests/test_rmwhub_adapter.py
@@ -1130,6 +1130,62 @@ class TestRmwHubAdapter:
         assert device["last_updated"] == "2023-09-20T10:00:00+00:00"
         assert device["recorded_at"] == "2023-09-20T10:00:00+00:00"
 
+    @staticmethod
+    def _make_gearset_with_release_type(release_type):
+        trap = Trap(
+            id="trap_001",
+            sequence=1,
+            latitude=-42.8509254,
+            longitude=147.3067216,
+            deploy_datetime_utc="2023-09-15T14:30:00Z",
+            surface_datetime_utc=None,
+            retrieved_datetime_utc=None,
+            status="deployed",
+            accuracy="gps",
+            release_type=release_type,
+            is_on_end=True,
+        )
+        gearset = GearSet(
+            vessel_id="vessel_001",
+            id="gearset_001",
+            deployment_type="trawl",
+            traps_in_set=1,
+            trawl_path={},
+            share_with=[],
+            when_updated_utc="2023-09-15T18:00:00Z",
+            traps=[trap],
+        )
+        return gearset, trap
+
+    @pytest.mark.parametrize(
+        "raw_release_type,expected",
+        [
+            ("Acoustic", "acoustic"),  # RMW Hub sends mixed casing (e.g. Fiomarine traps)
+            ("ACOUSTIC", "acoustic"),
+            ("timed", "timed"),
+            ("Galvanic", "galvanic"),
+        ],
+    )
+    def test_create_gear_payload_normalizes_release_type_casing(self, adapter, raw_release_type, expected):
+        """release_type is lowercased so the Buoy API ChoiceField accepts it (400 otherwise)."""
+        gearset, trap = self._make_gearset_with_release_type(raw_release_type)
+
+        result = adapter._create_gear_payload_from_gearset(gearset, [trap], "deployed")
+
+        assert result["devices"][0]["release_type"] == expected
+
+    @pytest.mark.parametrize("raw_release_type", ["none", "None", "", None, "manual", "unknown-type"])
+    def test_create_gear_payload_omits_unsupported_release_type(self, adapter, raw_release_type):
+        """Unsupported/none release types are omitted so the whole gearset isn't rejected."""
+        gearset, trap = self._make_gearset_with_release_type(raw_release_type)
+
+        result = adapter._create_gear_payload_from_gearset(gearset, [trap], "deployed")
+
+        device = result["devices"][0]
+        assert "release_type" not in device
+        # Raw value still preserved for traceability
+        assert device["device_additional_data"]["release_type"] == raw_release_type
+
     def test_create_gear_payload_from_gearset_hauled_with_retrieved(self, adapter):
         """Test creating gear payload for hauled traps uses retrieved_datetime_utc for recorded_at."""
         trap = Trap(
@@ -1278,7 +1334,7 @@ class TestRmwHubAdapter:
             retrieved_datetime_utc=None,
             status="deployed",
             accuracy="gps",
-            release_type="manual",
+            release_type="galvanic",
             is_on_end=False
         )
         trap2 = Trap(
@@ -1316,7 +1372,7 @@ class TestRmwHubAdapter:
         assert result["devices"][1]["recorded_at"] == "2023-09-15T14:35:00+00:00"
         
         # Check release_type handling
-        assert result["devices"][0]["release_type"] == "manual"
+        assert result["devices"][0]["release_type"] == "galvanic"
         assert result["devices"][1]["release_type"] == "timed"
 
     def test_create_gear_payload_from_gearset_release_type_none(self, adapter):


### PR DESCRIPTION
## Problem

Gearset `1177d973-6b58-4ef9-a5cd-a22ba5280d22` (and any other set with a mixed-case `release_type`) never appears in EarthRanger. RMW Hub sends `release_type: "Acoustic"` (capital A, Fiomarine trap), but the Buoy API's `release_type` ChoiceField only accepts lowercase `timed` / `acoustic` / `galvanic`. The 400 rejects the **whole gearset payload**, so every trap in the set is dropped — on every sync, forever.

Caught by the Playwright integration test `All Deployed Traps in RMWHub Are Present in /gear` (2 traps missing).

Live RMW data confirms the casing inconsistency (`release_type` counts from a 2-day `search_hub` snapshot): `"acoustic"` ×239, `"Acoustic"` ×28, `""` ×28, `"none"` ×21.

## Fix

Lowercase `release_type` before adding it to the gear payload — same treatment `deployment_type` already gets in `GearSet.normalize_deployment_type`. Empty/`none` values are omitted as before. No value whitelist: the Buoy API remains the single source of truth for which values are valid.

## Tests

- New parametrized tests covering casing normalization and empty/none omission.
- Full suite: 192 passed, 23 skipped.

## Verification against production

Ran the fixed adapter code from this branch manually (download → `process_download` → POST to `buoy.pamdas.org`), scoped to the affected gearset only:

- Payload contained `"release_type": "acoustic"` (raw `"Acoustic"` preserved in `device_additional_data`); the trap with empty `release_type` had the field omitted.
- Buoy API accepted it: **201 Created**.
- Both previously-missing traps (`d5664de3…`, `a194e063…`) are now deployed in ER `/gear` under set `1177d973…` with correct coordinates and `last_deployed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)