### PR TITLE
fix: skip deploy payload for partially retrieved sets already in ER

### DIFF
--- a/app/actions/rmwhub/adapter.py
+++ b/app/actions/rmwhub/adapter.py
@@ -375,8 +375,24 @@ class RmwHubAdapter:
                         gearset.id, dropped + 1, trap_id,
                     )
             
+            # A gearset with ≥1 retrieved trap in RMW must end up hauled in ER (whole-set
+            # haul rule below). When such a set already exists in ER, its still-"deployed"
+            # RMW traps mismatch ER's hauled state every sync and land in traps_to_deploy;
+            # re-deploying them would reactivate the hauled set and ping-pong it between
+            # deployed and hauled on every run until RMW retires the remaining traps.
+            # Skip the deploy payload instead. A genuinely redeployed set (RMW reuses the
+            # set_id after an accidental haul) reports all traps as "deployed", so it
+            # still takes the deploy path below.
+            has_retrieved_trap = any(trap.status == "retrieved" for trap in gearset.traps)
+            if traps_to_deploy and not traps_to_haul and er_gear and has_retrieved_trap:
+                logger.info(
+                    "Skipping deployment payload for gear set %s: RMW still reports ≥1 retrieved trap "
+                    "and the set exists in ER (status=%s); re-deploying would reactivate a hauled set",
+                    gearset.id,
+                    er_gear.status,
+                )
             # Create gear payloads for deployment
-            if traps_to_deploy and not traps_to_haul:
+            elif traps_to_deploy and not traps_to_haul:
                 # When the set already exists in ER and we have new traps to deploy (e.g. device moved
                 # from another set), send the full trap list for this set so the Buoy API can update
                 # set membership. Sending only the new device can be ignored if the device already

--- a/app/actions/tests/test_rmwhub_adapter.py
+++ b/app/actions/tests/test_rmwhub_adapter.py
@@ -1000,10 +1000,186 @@ class TestRmwHubAdapter:
         )
         
         adapter.gear_client.get_all_gears = AsyncMock(return_value=[])
-        
+
         result = await adapter.process_download([gearset])
-        
+
         assert result == []  # Should skip retrieved trap with no ER gear
+
+    @pytest.mark.asyncio
+    async def test_process_download_skips_deploy_for_partially_retrieved_set_hauled_in_er(self, adapter):
+        """A set hauled in ER with ≥1 retrieved trap in RMW must NOT get a deployment
+        payload for its remaining "deployed" RMW traps.
+
+        Regression for the deploy/haul ping-pong: after the whole-set haul, RMW keeps
+        reporting the non-retrieved trap as "deployed"; re-deploying it reactivates the
+        hauled set in ER, which triggers a whole-set haul on the next run, and so on
+        every sync cycle until RMW retires the remaining trap.
+        """
+        set_id = uuid.uuid4()
+        trap_id_retrieved = str(uuid.uuid4())
+        trap_id_deployed = str(uuid.uuid4())
+
+        gearset = GearSet(
+            vessel_id="vessel_001",
+            id=str(set_id),
+            deployment_type="trawl",
+            traps_in_set=2,
+            trawl_path={},
+            share_with=[],
+            when_updated_utc="2023-09-15T18:00:00Z",
+            traps=[
+                Trap(
+                    id=trap_id_retrieved,
+                    sequence=1,
+                    latitude=42.123456,
+                    longitude=-71.987654,
+                    deploy_datetime_utc="2023-09-10T14:30:00Z",
+                    surface_datetime_utc=None,
+                    retrieved_datetime_utc="2023-09-15T17:30:00Z",
+                    status="retrieved",
+                    accuracy="gps",
+                    release_type="acoustic",
+                    is_on_end=True,
+                ),
+                Trap(
+                    id=trap_id_deployed,
+                    sequence=2,
+                    latitude=42.223456,
+                    longitude=-71.887654,
+                    deploy_datetime_utc="2023-09-10T14:35:00Z",
+                    surface_datetime_utc=None,
+                    retrieved_datetime_utc=None,
+                    status="deployed",
+                    accuracy="gps",
+                    release_type="acoustic",
+                    is_on_end=True,
+                ),
+            ],
+        )
+
+        er_gear = BuoyGear(
+            id=set_id,
+            display_id="gear_001",
+            name="Test Gear",
+            status="hauled",
+            last_updated=datetime.now(timezone.utc),
+            devices=[
+                BuoyDevice(
+                    device_id=trap_id_retrieved,
+                    mfr_device_id="mfr_001",
+                    label="Device 1",
+                    location=DeviceLocation(latitude=42.123456, longitude=-71.987654),
+                    last_updated=datetime.now(timezone.utc),
+                    last_deployed=datetime.now(timezone.utc),
+                ),
+                BuoyDevice(
+                    device_id=trap_id_deployed,
+                    mfr_device_id="mfr_002",
+                    label="Device 2",
+                    location=DeviceLocation(latitude=42.223456, longitude=-71.887654),
+                    last_updated=datetime.now(timezone.utc),
+                    last_deployed=datetime.now(timezone.utc),
+                ),
+            ],
+            type="buoy",
+            manufacturer="rmwhub",
+            additional={},
+        )
+
+        adapter.gear_client.get_all_gears = AsyncMock(return_value=[er_gear])
+
+        result = await adapter.process_download([gearset])
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_process_download_redeploys_hauled_set_when_all_traps_deployed(self, adapter):
+        """A hauled ER set whose RMW traps are ALL "deployed" is a genuine redeploy
+        (RMW reuses the set_id after an accidental haul) and must still get a
+        deployment payload — the ping-pong guard only applies while RMW reports a
+        retrieved trap in the set.
+        """
+        set_id = uuid.uuid4()
+        trap_id_a = str(uuid.uuid4())
+        trap_id_b = str(uuid.uuid4())
+
+        gearset = GearSet(
+            vessel_id="vessel_001",
+            id=str(set_id),
+            deployment_type="trawl",
+            traps_in_set=2,
+            trawl_path={},
+            share_with=[],
+            when_updated_utc="2023-09-16T09:00:00Z",
+            traps=[
+                Trap(
+                    id=trap_id_a,
+                    sequence=1,
+                    latitude=42.123456,
+                    longitude=-71.987654,
+                    deploy_datetime_utc="2023-09-16T08:30:00Z",
+                    surface_datetime_utc=None,
+                    retrieved_datetime_utc=None,
+                    status="deployed",
+                    accuracy="gps",
+                    release_type="acoustic",
+                    is_on_end=True,
+                ),
+                Trap(
+                    id=trap_id_b,
+                    sequence=2,
+                    latitude=42.223456,
+                    longitude=-71.887654,
+                    deploy_datetime_utc="2023-09-16T08:35:00Z",
+                    surface_datetime_utc=None,
+                    retrieved_datetime_utc=None,
+                    status="deployed",
+                    accuracy="gps",
+                    release_type="acoustic",
+                    is_on_end=True,
+                ),
+            ],
+        )
+
+        er_gear = BuoyGear(
+            id=set_id,
+            display_id="gear_001",
+            name="Test Gear",
+            status="hauled",
+            last_updated=datetime.now(timezone.utc),
+            devices=[
+                BuoyDevice(
+                    device_id=trap_id_a,
+                    mfr_device_id="mfr_001",
+                    label="Device 1",
+                    location=DeviceLocation(latitude=42.123456, longitude=-71.987654),
+                    last_updated=datetime.now(timezone.utc),
+                    last_deployed=datetime.now(timezone.utc),
+                ),
+                BuoyDevice(
+                    device_id=trap_id_b,
+                    mfr_device_id="mfr_002",
+                    label="Device 2",
+                    location=DeviceLocation(latitude=42.223456, longitude=-71.887654),
+                    last_updated=datetime.now(timezone.utc),
+                    last_deployed=datetime.now(timezone.utc),
+                ),
+            ],
+            type="buoy",
+            manufacturer="rmwhub",
+            additional={},
+        )
+
+        adapter.gear_client.get_all_gears = AsyncMock(return_value=[er_gear])
+
+        result = await adapter.process_download([gearset])
+
+        assert len(result) == 1
+        payload = result[0]
+        assert payload["set_id"] == str(set_id).lower()
+        device_ids = [d["device_id"] for d in payload["devices"]]
+        assert sorted(device_ids) == sorted([trap_id_a.lower(), trap_id_b.lower()])
+        assert all(d["device_status"] == "deployed" for d in payload["devices"])
 
     @pytest.mark.asyncio
     async def test_create_rmw_update_from_rmwhub_gear(self, adapter):


### PR DESCRIPTION
## Problem

A gearset that is partially retrieved in RMW Hub (e.g. a trawl with one end up, one still in the water) ping-pongs between `hauled` and `deployed` in ER on every ~3-minute sync cycle:

1. A trap is retrieved in RMW → the adapter correctly sends a **whole-set haul** (`adapter.py` whole-gearset haul rule).
2. Next run: the retrieved trap now matches ER (`retrieved` ↔ `hauled`) and is skipped, so `traps_to_haul` is empty — but the remaining RMW trap is still `deployed` and mismatches ER's `hauled` state, landing in `traps_to_deploy`.
3. The adapter sends a deploy payload for that trap; the Buoy API reactivates the hauled set (server-side redeploy path from ERA-13736).
4. Next run: the retrieved trap mismatches again → whole-set haul → back to step 2. This repeats until RMW retires the remaining traps.

Caught by the Playwright integration test `Retrieved traps in RMWHub are hauled in /gear` (set `62dd9236-f5b5-4aee-836c-9fed3f5f1550` observed mid-cycle as `deployed` with 1 device).

## Fix

Guard the deploy branch in `process_download`: if the set already exists in ER and RMW still reports **any** retrieved trap in it, skip the deployment payload (with an info log). Genuine redeploys (RMW reuses a set_id with **all** traps `deployed`) still take the deploy path, so ERA-13736 reactivation keeps working.

No data cleanup needed: sets currently caught mid-cycle converge to `hauled` on the next run and the guard keeps them there.

## Tests

- `test_process_download_skips_deploy_for_partially_retrieved_set_hauled_in_er` — reproduces the production scenario; fails without the fix (verified by revert-check).
- `test_process_download_redeploys_hauled_set_when_all_traps_deployed` — pins the legitimate redeploy/reactivation flow.
- Full adapter suite: 81 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)